### PR TITLE
fix(thought-chain): fix visible trigger on ssr

### DIFF
--- a/src/thought-chain/item.vue
+++ b/src/thought-chain/item.vue
@@ -123,7 +123,8 @@ defineRender(() => {
       {/* Content */}
       {content.value && (
         // TODO: add animation
-        contentVisible.value && (<div
+        <div
+          v-show={contentVisible.value}
           class={classnames(`${itemCls.value}-content`)}
         >
           <div
@@ -132,7 +133,7 @@ defineRender(() => {
           >
             {content.value}
           </div>
-        </div>)
+        </div>
         // <CSSMotion {...collapseMotion} visible={enableCollapse.value ? contentOpen.value : true}>
         //   {({ className: motionClassName, style }, motionRef) => (
         //     <div


### PR DESCRIPTION
第二次展开面板为空，是由于条件渲染的dom与ssr渲染结果不一致，导致水合不匹配。
收起时不应该将dom移除，而是隐藏，我已将其调整为`v-show`，确保dom结构稳定。

Close #6 