### PR TITLE
fix(type): fix the prop type check failed

### DIFF
--- a/src/bubble/interface.ts
+++ b/src/bubble/interface.ts
@@ -1,4 +1,5 @@
 import type { AvatarProps } from 'ant-design-vue';
+import type { AvoidValidation } from '../type-utility';
 import type { CSSProperties, HTMLAttributes, VNode } from 'vue';
 
 export interface TypingOption {
@@ -31,7 +32,7 @@ export interface BubbleProps extends /* @vue-ignore */ Omit<HTMLAttributes, 'con
   avatar?: Partial<_AvatarProps> | VNode;
   placement?: 'start' | 'end';
   loading?: boolean;
-  typing?: boolean | TypingOption;
+  typing?: AvoidValidation<TypingOption | boolean>;
   content?: VNode | object | string;
   messageRender?: (content: string) => VNode | string;
   loadingRender?: () => VNode;
@@ -74,5 +75,5 @@ export interface BubbleListProps extends /* @vue-ignore */ HTMLAttributes {
   rootClassName?: string;
   items?: BubbleDataType[];
   autoScroll?: boolean;
-  roles?: RolesType;
+  roles?: AvoidValidation<RolesType>;
 }

--- a/src/sender/interface.ts
+++ b/src/sender/interface.ts
@@ -4,6 +4,7 @@ import type { ConfigProviderProps } from "ant-design-vue/es/config-provider/cont
 import type { CSSProperties, VNode, } from "vue";
 import type { AllowSpeech } from "./useSpeech";
 import type { InputRef } from "ant-design-vue/es/vc-input/inputProps";
+import type { AvoidValidation } from '../type-utility';
 import SendButton from "./components/SendButton.vue";
 import ClearButton from "./components/ClearButton.vue";
 import LoadingButton from "./components/LoadingButton.vue";
@@ -60,7 +61,7 @@ export interface SenderProps extends Pick<TextAreaProps, 'placeholder'> {
   style?: CSSProperties;
   className?: string;
   actions?: VNode | ActionsRender;
-  allowSpeech?: AllowSpeech;
+  allowSpeech?: AvoidValidation<AllowSpeech>;
   prefix?: VNode;
   header?: VNode;
 }

--- a/src/sender/useSpeech.ts
+++ b/src/sender/useSpeech.ts
@@ -1,5 +1,5 @@
 import useMergedState from '../_util/hooks/useMergedState';
-import { computed, ref, watchEffect, MaybeRefOrGetter, toValue, onWatcherCleanup } from 'vue';
+import { computed, ref, watchEffect, type MaybeRefOrGetter, toValue, onWatcherCleanup } from 'vue';
 
 // Ensure that the SpeechRecognition API is available in the browser
 let SpeechRecognition: any;

--- a/src/type-utility.ts
+++ b/src/type-utility.ts
@@ -1,0 +1,1 @@
+export type AvoidValidation<T> = T;


### PR DESCRIPTION
About #38 .

TS类型声明正确，并无问题，但与vue编译系统配合不佳，导致prop校验失败，这可能与vue编译基于类型的Props有关，有如下相关问题可参考：

https://github.com/vuejs/core/issues/6532

About: [vue issues](https://github.com/vuejs/core/issues?q=is%3Aissue%20state%3Aopen%20Invalid%20prop%3A%20type%20check%20failed%20for%20prop)

所幸可以通过如下方式规避( refer https://github.com/vuejs/core/issues/5471#issuecomment-1294867826 ):

```ts
type AvoidValidation<T> = T
 
defineProps<{
  modelValue: AvoidValidation<string | undefined>
}>()
```

由此可以提供正确的开发IDE提示体验，且功能不受影响。