### PR TITLE
feat: add CollapseTransion to SenderHeader

### DIFF
--- a/src/sender/CollapseTransition.vue
+++ b/src/sender/CollapseTransition.vue
@@ -1,0 +1,86 @@
+<script lang="ts" setup>
+import { computed, Transition, type RendererElement } from 'vue'
+
+defineOptions({ name: 'AXCollapseTransition' })
+
+const props = defineProps<{
+  prefixCls: string
+}>()
+
+const name = computed(() => {
+  return props.prefixCls + '-collapse-transition'
+})
+
+const on = {
+  beforeEnter (el: RendererElement) {
+    if (!el.dataset)
+      el.dataset = {}
+
+    el.dataset.oldPaddingTop = el.style.paddingTop
+    el.dataset.oldPaddingBottom = el.style.paddingBottom
+
+    el.style.maxHeight = 0
+    el.style.paddingTop = 0
+    el.style.paddingBottom = 0
+  },
+
+  enter (el: RendererElement) {
+    el.dataset.oldOverflow = el.style.overflow
+
+    if (el.scrollHeight !== 0) {
+      el.style.maxHeight = `${el.scrollHeight}px`
+      el.style.paddingTop = el.dataset.oldPaddingTop
+      el.style.paddingBottom = el.dataset.oldPaddingBottom
+    }
+    else {
+      el.style.maxHeight = `${el.dataset.oldMaxHeight || 999}px`
+      el.style.paddingTop = el.dataset.oldPaddingTop
+      el.style.paddingBottom = el.dataset.oldPaddingBottom
+    }
+
+    el.style.overflow = 'hidden'
+  },
+
+  afterEnter (el: RendererElement) {
+    el.style.maxHeight = ''
+    el.style.overflow = el.dataset.oldOverflow
+  },
+
+  beforeLeave (el: RendererElement) {
+    if (!el.dataset)
+      el.dataset = {}
+    el.dataset.oldMaxHeight = el.scrollHeight
+    el.dataset.oldPaddingTop = el.style.paddingTop
+    el.dataset.oldPaddingBottom = el.style.paddingBottom
+    el.dataset.oldOverflow = el.style.overflow
+
+    el.style.overflow = 'hidden'
+    el.style.maxHeight = `${el.scrollHeight}px`
+  },
+
+  leave (el: RendererElement) {
+    if (el.scrollHeight !== 0) {
+      el.style.maxHeight = 0
+      el.style.paddingTop = 0
+      el.style.paddingBottom = 0
+    }
+  },
+
+  afterLeave (el: RendererElement) {
+    el.style.maxHeight = ''
+    el.style.overflow = el.dataset.oldOverflow
+    el.style.paddingTop = el.dataset.oldPaddingTop
+    el.style.paddingBottom = el.dataset.oldPaddingBottom
+  },
+}
+</script>
+
+<template>
+  <Transition
+    :name="name"
+    v-on="on"
+  >
+    <slot />
+  </Transition>
+</template>
+

--- a/src/sender/SenderHeader.vue
+++ b/src/sender/SenderHeader.vue
@@ -4,13 +4,18 @@ import { Button } from 'ant-design-vue';
 import classNames from 'classnames';
 import type { SenderHeaderProps } from './interface';
 import { useSenderHeaderContextInject } from './context';
-import { computed } from 'vue';
+import { computed, useAttrs } from 'vue';
+import CollapseTransition from './CollapseTransition.vue'
 
 const slots = defineSlots<{
   default(props?: any): any
 }>();
 
-defineOptions({ name: 'AXSenderHeader' });
+defineOptions({
+  name: 'AXSenderHeader',
+  inheritAttrs: false
+});
+
 
 const {
   title,
@@ -27,56 +32,62 @@ const {
 const SendHeaderContext = useSenderHeaderContextInject()
 
 const headerCls = computed(() => `${SendHeaderContext.value.prefixCls}-header`)
+const attrs = useAttrs();
 defineRender(() => {
-  // TODO：未使用 CSSMotion，缺少展示动画
   return (
-    open && <div
-      class={classNames(headerCls.value, className)}
-      style={{
-        ...style,
-      }}
-    >
-      {/* Header */}
-      {(closable !== false || title) && (
-        <div
-          class={
-            // We follow antd naming standard here.
-            // So the header part is use `-header` suffix.
-            // Though its little bit weird for double `-header`.
-            classNames(`${headerCls.value}-header`, classes.header)
-          }
+    <CollapseTransition prefixCls={headerCls.value}>
+      {
+        open && <div
+          {...attrs}
+          class={classNames(headerCls.value, className)}
           style={{
-            ...styles.header,
+            ...style,
           }}
         >
-          <div class={`${headerCls.value}-title`}>{title}</div>
-          {closable !== false && (
-            <div class={`${headerCls.value}-close`}>
-              <Button
-                type="text"
-                icon={<CloseOutlined />}
-                size="small"
-                onClick={() => {
-                  onOpenChange?.(!open);
-                }}
-              />
+          {/* Header */}
+          {(closable !== false || title) && (
+            <div
+              class={
+                // We follow antd naming standard here.
+                // So the header part is use `-header` suffix.
+                // Though its little bit weird for double `-header`.
+                classNames(`${headerCls.value}-header`, classes.header)
+              }
+              style={{
+                ...styles.header,
+              }}
+            >
+              <div class={`${headerCls.value}-title`}>{title}</div>
+              {closable !== false && (
+                <div class={`${headerCls.value}-close`}>
+                  <Button
+                    type="text"
+                    icon={<CloseOutlined />}
+                    size="small"
+                    onClick={() => {
+                      onOpenChange?.(!open);
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Content */}
+          {slots.default && (
+            <div
+              class={classNames(`${headerCls.value}-content`, classes.content)}
+              style={{
+                ...styles.content,
+              }}
+            >
+              {slots.default?.()}
             </div>
           )}
         </div>
-      )}
+      }
 
-      {/* Content */}
-      {slots.default && (
-        <div
-          class={classNames(`${headerCls.value}-content`, classes.content)}
-          style={{
-            ...styles.content,
-          }}
-        >
-          {slots.default?.()}
-        </div>
-      )}
-    </div>
+    </CollapseTransition>
   )
 });
 </script>

--- a/src/sender/style/header.ts
+++ b/src/sender/style/header.ts
@@ -1,5 +1,5 @@
-import type { GenerateStyle } from '../../theme/cssinjs-utils';
 import type { SenderToken } from '.';
+import type { GenerateStyle } from '../../theme/cssinjs-utils';
 
 const genSenderHeaderStyle: GenerateStyle<SenderToken> = (token) => {
   const { componentCls, calc } = token;
@@ -12,7 +12,6 @@ const genSenderHeaderStyle: GenerateStyle<SenderToken> = (token) => {
         borderBottomWidth: token.lineWidth,
         borderBottomStyle: 'solid',
         borderBottomColor: token.colorBorder,
-
         // ======================== Header ========================
         '&-header': {
           background: token.colorFillAlter,
@@ -48,10 +47,30 @@ const genSenderHeaderStyle: GenerateStyle<SenderToken> = (token) => {
             display: 'none',
           },
         },
+
+        // ========================= CollapseTransition ========================
+        '&-collapse-transition': {
+          '&-enter-active': {
+            transition: ['max-height', 'padding-top', 'padding-bottom']
+              .map(
+                (prop) =>
+                  `${prop} ${token.motionDurationSlow} ${token.motionEaseInOut}`,
+              )
+              .join(','),
+          },
+
+          '&-leave-active': {
+            transition: ['max-height', 'padding-top', 'padding-bottom']
+              .map(
+                (prop) =>
+                  `${prop} ${token.motionDurationSlow} ${token.motionEaseInOut}`,
+              )
+              .join(','),
+          },
+        },
       },
     },
   };
 };
 
 export default genSenderHeaderStyle;
-


### PR DESCRIPTION
About: #42 

为 SenderHeader 添加了动画

![SendHeader](https://github.com/user-attachments/assets/11e6d203-f11e-480e-864b-226cd804ff35)

添加了 CollapseTransion.vue 组件，目前只用作于 SenderHeader .

考虑到 Transion 对于整个仓库的通用性，未来可能移动到全局中?
