### PR TITLE
fix(conversations): fix item label render err when it is a vnode

### DIFF
--- a/src/conversations/ConversationsItem.vue
+++ b/src/conversations/ConversationsItem.vue
@@ -77,8 +77,7 @@ defineRender(() => {
           ellipsis={{
             onEllipsis,
           }}
-          content={info.label as string}
-        />
+        >{info.label}</Typography.Text>
         {menu && !disabled.value && (
           <Dropdown
             placement={direction === 'rtl' ? 'bottomLeft' : 'bottomRight'}


### PR DESCRIPTION
And Design Vue Typography.Text 组件开启省略时仅支持string，导致vnode渲染错误：
<img width="465" alt="image" src="https://github.com/user-attachments/assets/811b3993-27c0-462d-9959-ecc60f64aaeb" />

pr将item label改为Typography.Text 默认插槽实现。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the display consistency of conversation labels. The update revises how labels are rendered in conversation items, resulting in a more natural and integrated text presentation across the interface. This change ensures that label text appears uniformly, improving the overall visual experience for end users. This improvement contributes to a refined and reliable experience when navigating conversation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->