### PR TITLE
fix(Attachments): fix Attachments broken image

### DIFF
--- a/src/attachments/FileList/FileListCard.vue
+++ b/src/attachments/FileList/FileListCard.vue
@@ -185,7 +185,7 @@ const content = computed(() => {
     // Preview Image style
     return (
       <>
-        <img alt="preview" src={previewUrl.value} />
+        {previewUrl.value && <img alt="preview" src={previewUrl.value} />}
 
         {status.value !== 'done' && (
           <div class={`${cardCls}-img-mask`}>


### PR DESCRIPTION
修复使用 Attachment 组件上传图片时，图片在初始状态下会显示为破损图片，之后恢复正常
<img width="431" alt="image" src="https://github.com/user-attachments/assets/8f6bc643-73ec-4eb6-bf2c-5ad9139eb8f5" />
<img width="506" alt="image" src="https://github.com/user-attachments/assets/087c831a-094b-43f2-af83-4bdbe66f9c42" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file preview display so that preview images appear only when valid, preventing broken or empty visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->