### PR TITLE
docs(attachments): add with sender demo and update basic demo

### DIFF
--- a/docs/component/attachments.md
+++ b/docs/component/attachments.md
@@ -33,6 +33,14 @@ attachments/overflow
 
 :::
 
+### 组合示例
+
+:::demo 配合 Sender.Header 使用，在对话中插入附件。
+
+attachments/with-sender
+
+:::
+
 ### 文件卡片
 
 :::demo 单独的文件卡片，用于一些展示场景。

--- a/docs/examples/attachments/basic.vue
+++ b/docs/examples/attachments/basic.vue
@@ -1,8 +1,8 @@
 <script setup lang="tsx">
 import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons-vue';
 import { App, Button, Flex, Switch } from 'ant-design-vue';
-import { Attachments } from 'ant-design-x-vue';
-import { ref, useTemplateRef } from 'vue';
+import { Sender, Attachments } from 'ant-design-x-vue';
+import { ref, computed, useTemplateRef } from 'vue';
 
 defineOptions({ name: 'AXAttachmentBasic' });
 
@@ -20,22 +20,25 @@ const Demo = () => {
     customContent.value = v
   }
 
+  const attachmentsNode = computed(() => (
+    <Attachments
+      beforeUpload={() => false}
+      onChange={({ file }) => {
+        message.info(`Mock upload: ${file.name}`);
+      }}
+      getDropContainer={() => (fullScreenDrop.value ? document.body : divRef.value)}
+      placeholder={{
+        icon: <CloudUploadOutlined />,
+        title: 'Drag & Drop files here',
+        description: 'Support file type: image, video, audio, document, etc.',
+      }}
+      children={customContent.value && <Button type="text" icon={<LinkOutlined />} />}
+    />));
+
   return (
     <div ref="basic-container">
       <Flex vertical gap="middle" align="flex-start">
-        <Attachments
-          beforeUpload={() => false}
-          onChange={({ file }) => {
-            message.info(`Mock upload: ${file.name}`);
-          }}
-          getDropContainer={() => (fullScreenDrop.value ? document.body : divRef.value)}
-          placeholder={{
-            icon: <CloudUploadOutlined />,
-            title: 'Drag & Drop files here',
-            description: 'Support file type: image, video, audio, document, etc.',
-          }}
-          children={customContent.value && <Button type="text" icon={<LinkOutlined />} />}
-        />
+        <Sender prefix={attachmentsNode.value} />
         <Switch
           checked={fullScreenDrop.value}
           onChange={(checked) => {

--- a/docs/examples/attachments/with-sender.vue
+++ b/docs/examples/attachments/with-sender.vue
@@ -1,0 +1,82 @@
+<script setup lang="tsx">
+import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons-vue';
+import { App, Button, Flex } from 'ant-design-vue';
+import { Attachments, Sender } from 'ant-design-x-vue';
+import { computed, ref } from 'vue';
+
+defineOptions({ name: 'AXAttachmentWithSender' });
+
+const Demo = () => {
+  const open = ref(true);
+  const items = ref([]);
+  const text = ref('');
+
+  const senderRef = ref<InstanceType<typeof Sender>>(null);
+
+  const senderHeader = computed(() => (
+    <Sender.Header
+      title="Attachments"
+      styles={{
+        content: {
+          padding: 0,
+        },
+      }}
+      open={open.value}
+      onOpenChange={v => open.value = v}
+      forceRender
+    >
+      <Attachments
+        // Mock not real upload file
+        beforeUpload={() => false}
+        items={items.value}
+        onChange={({ fileList }) => items.value = fileList}
+        placeholder={(type) =>
+          type === 'drop'
+            ? {
+              title: 'Drop file here',
+            }
+            : {
+              icon: <CloudUploadOutlined />,
+              title: 'Upload files',
+              description: 'Click or drag files to this area to upload',
+            }
+        }
+        getDropContainer={() => senderRef.value?.nativeElement}
+      />
+    </Sender.Header>
+  ));
+
+  const badgeNode = computed(() => (
+    <Badge dot={items.value.length > 0 && !headerOpen.value}>
+      <Button onClick={() => open.value = !open.value} icon={<LinkOutlined />} />
+    </Badge>
+  ))
+
+  return (
+    <Flex style={{ minHeight: 250 }} align="flex-end">
+      <Sender
+        ref={senderRef}
+        header={senderHeader.value}
+        prefix={
+          badgeNode.value
+        }
+        value={text.value}
+        onChange={v => text.value = v}
+        onSubmit={() => {
+          items.value = []
+          text.value = ''
+        }}
+      />
+    </Flex>
+  );
+};
+
+defineRender(() => {
+  return (
+    <App>
+      <Demo />
+    </App>
+  )
+});
+
+</script>

--- a/docs/examples/attachments/with-sender.vue
+++ b/docs/examples/attachments/with-sender.vue
@@ -1,6 +1,6 @@
 <script setup lang="tsx">
 import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons-vue';
-import { App, Button, Flex } from 'ant-design-vue';
+import { App, Button, Flex, Badge } from 'ant-design-vue';
 import { Attachments, Sender } from 'ant-design-x-vue';
 import { computed, ref } from 'vue';
 
@@ -47,7 +47,7 @@ const Demo = () => {
   ));
 
   const badgeNode = computed(() => (
-    <Badge dot={items.value.length > 0 && !headerOpen.value}>
+    <Badge dot={items.value.length > 0 && !open.value}>
       <Button onClick={() => open.value = !open.value} icon={<LinkOutlined />} />
     </Badge>
   ))


### PR DESCRIPTION
添加配合 Sender.Header 使用的 Demo，并使用 Sender 更新了基础 Demo
<img width="583" alt="image" src="https://github.com/user-attachments/assets/c80c5f96-9a43-4d6e-b020-f66e7622f93c" />
<img width="650" alt="image" src="https://github.com/user-attachments/assets/d75c4f22-ccc1-4615-b45a-ef05f21b3c25" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section titled "组合示例" in the attachments documentation, showcasing how to use the Attachments component with the Sender.Header.
- **New Features**
  - Updated demo examples to illustrate a more encapsulated approach to integrating attachments with the Sender component.
  - Introduced a new component, `AXAttachmentWithSender`, demonstrating the combined functionality of attachments and messaging elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->