### PR TITLE
feat: add stackblitz playground

### DIFF
--- a/docs/.vitepress/plugins/demo.ts
+++ b/docs/.vitepress/plugins/demo.ts
@@ -26,6 +26,7 @@ function createDemoContainer(md: MarkdownIt): ContainerOpts {
     render(tokens, idx) {
       const m = tokens[idx].info.trim().match(/^demo\s*(.*)$/)
       if (tokens[idx].nesting === 1 /* means the tag is opening */) {
+        const title = tokens[idx - 2]?.children?.[0].content
         const description = m && m.length > 1 ? m[1] : ''
         const sourceFileToken = tokens[idx + 2]
         let source = ''
@@ -43,7 +44,7 @@ function createDemoContainer(md: MarkdownIt): ContainerOpts {
           md.render(`\`\`\` ts\n${source}\`\`\``)
         )}" path="${sourceFile}" raw-source="${encodeURIComponent(
           source
-        )}" description="${encodeURIComponent(md.render(description))}">
+        )}" description="${encodeURIComponent(md.render(description))}" title="${title}">
   <template #source><ax-${sourceFile.replaceAll('/', '-')}/></template>`
       } else {
         return '</Demo>\n'

--- a/docs/.vitepress/vitepress/components/vp-demo.vue
+++ b/docs/.vitepress/vitepress/components/vp-demo.vue
@@ -6,7 +6,7 @@ import { XProvider } from 'ant-design-x-vue'
 import { CaretUpFilled, CodepenOutlined, ThunderboltOutlined, FunctionOutlined } from '@ant-design/icons-vue'
 // import { useLang } from '../composables/lang'
 import { useSourceCode } from '../composables/source-code'
-// import { usePlayground } from '../composables/use-playground'
+import { usePlayground } from '../composables/use-playground'
 // import demoBlockLocale from '../../i18n/component/demo-block.json'
 import SourceCode from './demo/vp-source-code.vue'
 import { useData } from 'vitepress'
@@ -16,6 +16,7 @@ const props = defineProps<{
   path: string
   rawSource: string
   description: string
+  title: string
 }>()
 
 const vm = getCurrentInstance()!
@@ -38,12 +39,11 @@ const sourceCodeRef = ref<HTMLButtonElement>()
 // const locale = computed(() => demoBlockLocale[lang.value])
 const locale = computed(() => ({}));
 const decodedDescription = computed(() => decodeURIComponent(props.description))
-
-const onPlaygroundClick = () => {
-  // const { link } = usePlayground(props.rawSource)
-  if (!isClient) return
-  // window.open(link)
-}
+const { onStackblitzPlayBtnClick } = usePlayground({
+  title: props.title,
+  rawSource: props.rawSource,
+  path: props.path,
+})
 
 const onSourceVisibleKeydown = (e: KeyboardEvent) => {
   if (['Enter', 'Space'].includes(e.code)) {
@@ -85,11 +85,11 @@ const copyCode = async () => {
       <Divider style="margin: 0;" />
 
       <div class="op-btns">
-        <!-- <Tooltip>
-        <template #title>在 Stackblitz 中打开</template>
-<ThunderboltOutlined tabindex="0" role="link" class="op-btn" @click="onPlaygroundClick"
-  @keydown.prevent.enter="onPlaygroundClick" @keydown.prevent.space="onPlaygroundClick" />
-</Tooltip> -->
+        <Tooltip>
+          <template #title>在 Stackblitz 中打开</template>
+          <ThunderboltOutlined tabindex="0" role="link" class="op-btn" @click="onStackblitzPlayBtnClick"
+            @keydown.prevent.enter="onStackblitzPlayBtnClick" @keydown.prevent.space="onStackblitzPlayBtnClick" />
+        </Tooltip>
         <!-- <Tooltip>
         <template #title>在 CodePen 中打开</template>
         <CodepenOutlined

--- a/docs/.vitepress/vitepress/composables/use-playground.ts
+++ b/docs/.vitepress/vitepress/composables/use-playground.ts
@@ -1,0 +1,147 @@
+import stackblitzSdk from '@stackblitz/sdk';
+import type { Project as StackBlitzProject } from '@stackblitz/sdk';
+import pkg from '../../../../package.json' assert { type: 'json' };
+import { isClient } from '@vueuse/core'
+
+const pkgDependencyList = {
+  ...pkg.dependencies,
+  ...pkg.peerDependencies
+}
+
+interface Playground {
+  title: string;
+  rawSource: string;
+  path: string;
+}
+
+export function usePlayground({ title, rawSource, path }: Playground) {
+  const dependencies = (rawSource as string).split(/\n/).reduce<Record<PropertyKey, string>>(
+    (acc, line) => {
+      const matches = line.match(/import .+? from '(.+)';\r?$/);
+      if (matches?.[1]) {
+        const paths = matches[1].split('/');
+        const dep = paths[0].startsWith('@') ? `${paths[0]}/${paths[1]}` : paths[0];
+        acc[dep] ??= pkgDependencyList[dep] ?? 'latest';
+      }
+      return acc;
+    },
+    { 'ant-design-vue': pkgDependencyList['ant-design-vue'],
+      'ant-design-x-vue': pkg.version
+    
+    },
+  );
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Vue + TS</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+`
+  const mainTsContent = `import { createApp } from 'vue'
+import './style.css'
+import Demo from './Demo.vue'
+
+createApp(Demo).mount('#app')
+`
+  const styleCssContent = ``
+
+  const demoVueContent = `${decodeURIComponent(rawSource)}`
+
+  const tsconfig = {
+    compilerOptions: {
+      target: 'esnext',
+      module: 'esnext',
+      esModuleInterop: true,
+      moduleResolution: 'bundler',
+      jsx: "preserve",
+      jsxImportSource: "vue",
+    },
+  };
+
+  const packageJson = {
+    "name": `${path.replaceAll('/', '-')}`,
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+      "dev": "vite",
+      "build": "vue-tsc -b && vite build",
+      "preview": "vite preview"
+    },
+    "dependencies": {
+      ...dependencies
+    },
+    "devDependencies": {
+      "@vitejs/plugin-vue-jsx": pkg.devDependencies['@vitejs/plugin-vue-jsx'],
+      "@vitejs/plugin-vue": pkg.devDependencies['@vitejs/plugin-vue'],
+      "typescript": pkg.devDependencies.typescript,
+      "vite": pkg.devDependencies.vite,
+      "vue-tsc": pkg.devDependencies['vue-tsc'],
+      'unplugin-vue-macros': pkg.devDependencies['unplugin-vue-macros']
+    }
+  }
+
+  const viteTsContent = `import { defineConfig } from 'vite'
+import VueMacros from 'unplugin-vue-macros/vite'
+import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [
+    VueMacros({
+      plugins: {
+        vue: vue(),
+        vueJsx: vueJsx(),
+      }
+    }),
+  ],
+})
+`
+  const vueEnvTsContent = `declare module '*.vue' {
+  import { DefineComponent } from 'vue';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+  const component: DefineComponent<{}, {}, any>;
+
+  export default component;
+}
+`
+  
+
+  const stackblitzPrefillConfig: StackBlitzProject = {
+    title: `${title} - antd-design-x-vue@${pkg.version}`,
+    template: 'node',
+    description: '',
+    files: {
+      [`src/style.css`]: styleCssContent,
+      [`src/main.ts`]: mainTsContent,
+      [`src/Demo.vue`]: demoVueContent,
+      'index.html': html,
+      'tsconfig.json': JSON.stringify(tsconfig, null, 2),
+      'package.json': JSON.stringify(packageJson, null, 2),
+      'vite.config.ts': viteTsContent,
+      'vue.env.d.ts': vueEnvTsContent
+    },
+  };
+
+  const onStackblitzPlayBtnClick = () => {
+    if(!isClient) {
+      return
+    }
+    stackblitzSdk.openProject(stackblitzPrefillConfig, {
+      openFile: [`src/Demo.vue`],
+    });
+  }
+
+  return {
+    onStackblitzPlayBtnClick
+  }
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
     "@eslint/js": "^9.11.1",
+    "@stackblitz/sdk": "^1.11.0",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.10.2",
     "@types/react": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@eslint/js':
         specifier: ^9.11.1
         version: 9.17.0
+      '@stackblitz/sdk':
+        specifier: ^1.11.0
+        version: 1.11.0
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
@@ -1295,6 +1298,9 @@ packages:
 
   '@simonwep/pickr@1.8.2':
     resolution: {integrity: sha512-/l5w8BIkrpP6n1xsetx9MWPWlU6OblN5YgZZphxan0Tq4BByTCETL6lyIeY8lagalS2Nbt4F2W034KHLIiunKA==}
+
+  '@stackblitz/sdk@1.11.0':
+    resolution: {integrity: sha512-DFQGANNkEZRzFk1/rDP6TcFdM82ycHE+zfl9C/M/jXlH68jiqHWHFMQURLELoD8koxvu/eW5uhg94NSAZlYrUQ==}
 
   '@swc/core-darwin-arm64@1.9.2':
     resolution: {integrity: sha512-nETmsCoY29krTF2PtspEgicb3tqw7Ci5sInTI03EU5zpqYbPjoPH99BVTjj0OsF53jP5MxwnLI5Hm21lUn1d6A==}
@@ -5449,6 +5455,8 @@ snapshots:
     dependencies:
       core-js: 3.34.0
       nanopop: 2.4.2
+
+  '@stackblitz/sdk@1.11.0': {}
 
   '@swc/core-darwin-arm64@1.9.2':
     optional: true


### PR DESCRIPTION
- 文档demo添加stackblitz在线预览，目前预览示例是TSX示例。
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3e3bd0d2-3918-482f-9973-2abe7a685e6c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Demo displays now include dynamic titles that improve clarity and context.
  - Enhanced interactive code playground support enables users to launch live demos via an updated, easy-to-access button.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->