### PR TITLE
docs: add prompts/basic.vue setup usage example (#127) (#128)

### DIFF
--- a/docs/examples-setup/prompts/basic.vue
+++ b/docs/examples-setup/prompts/basic.vue
@@ -1,6 +1,64 @@
 <script setup lang="ts">
+import {
+  BulbOutlined,
+  InfoCircleOutlined,
+  RocketOutlined,
+  SmileOutlined,
+  WarningOutlined,
+} from '@ant-design/icons-vue';
+import { App } from 'ant-design-vue';
+import { Prompts, type PromptsProps } from 'ant-design-x-vue';
+import { h } from 'vue';
+
 defineOptions({ name: 'AXPromptsBasicSetup' });
+
+const items: PromptsProps['items'] = [
+  {
+    key: '1',
+    icon: h(BulbOutlined, { style: { color: '#FFD700' } }),
+    label: 'Ignite Your Creativity',
+    description: 'Got any sparks for a new project?',
+  },
+  {
+    key: '2',
+    icon: h(InfoCircleOutlined, { style: { color: '#1890FF' } }),
+    label: 'Uncover Background Info',
+    description: 'Help me understand the background of this topic.',
+  },
+  {
+    key: '3',
+    icon: h(RocketOutlined, { style: { color: '#722ED1' } }),
+    label: 'Efficiency Boost Battle',
+    description: 'How can I work faster and better?',
+  },
+  {
+    key: '4',
+    icon: h(SmileOutlined, { style: { color: '#52C41A' } }),
+    label: 'Tell me a Joke',
+    description: 'Why do not ants get sick? Because they have tiny ant-bodies!',
+  },
+  {
+    key: '5',
+    icon: h(WarningOutlined, { style: { color: '#FF4D4F' } }),
+    label: 'Common Issue Solutions',
+    description: 'How to solve common issues? Share some tips!',
+  },
+];
+
+const { message } = App.useApp();
+
 </script>
+
 <template>
-  <div>Needs to be supplemented.</div>
+  <App>
+    <Prompts
+      title="✨ Inspirational Sparks and Marvelous Tips"
+      :items="items"
+      :onItemClick="
+        (info) => {
+          message.success(`You clicked a prompt: ${info.data.label}`);
+        }
+      "
+    />
+  </App>
 </template>

--- a/docs/examples-setup/prompts/basic.vue
+++ b/docs/examples-setup/prompts/basic.vue
@@ -6,11 +6,13 @@ import {
   SmileOutlined,
   WarningOutlined,
 } from '@ant-design/icons-vue';
-import { App } from 'ant-design-vue';
+import { message as messageAnt } from 'ant-design-vue';
 import { Prompts, type PromptsProps } from 'ant-design-x-vue';
 import { h } from 'vue';
 
 defineOptions({ name: 'AXPromptsBasicSetup' });
+
+const [message, contextHolder] = messageAnt.useMessage();
 
 const items: PromptsProps['items'] = [
   {
@@ -45,20 +47,15 @@ const items: PromptsProps['items'] = [
   },
 ];
 
-const { message } = App.useApp();
-
 </script>
 
 <template>
-  <App>
-    <Prompts
-      title="✨ Inspirational Sparks and Marvelous Tips"
-      :items="items"
-      :onItemClick="
-        (info) => {
-          message.success(`You clicked a prompt: ${info.data.label}`);
-        }
-      "
-    />
-  </App>
+  <context-holder />
+  <Prompts
+    title="✨ Inspirational Sparks and Marvelous Tips"
+    :items="items"
+    :on-item-click="(info) => {
+      message.success(`You clicked a prompt: ${info.data.label}`);
+    }"
+  />
 </template>


### PR DESCRIPTION
完成 docs/examples-setup/prompts/basic.vue 文件代码；

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive prompt component that displays a structured list of options with icons, labels, and descriptions. Users can click on a prompt to trigger a success notification, enhancing engagement and visual appeal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->