### PR TITLE
docs(bubble): add think demo

### DIFF
--- a/docs/component/bubble.md
+++ b/docs/component/bubble.md
@@ -97,6 +97,14 @@ bubble/list-custom
 
 :::
 
+### 深度思考
+
+:::demo 带深度思考。
+
+bubble/with-think
+
+:::
+
 ### 使用 GPT-Vis 渲染图表 (no support)
 
 @antv/GPT-Vis 仅支持React。

--- a/docs/examples-setup/bubble/with-think.vue
+++ b/docs/examples-setup/bubble/with-think.vue
@@ -1,0 +1,6 @@
+<script setup lang="tsx">
+defineOptions({ name: 'AXBubbleWithThinkSetup' });
+</script>
+<template>
+  <div>Needs to be supplemented.</div>
+</template>

--- a/docs/examples/bubble/with-think.vue
+++ b/docs/examples/bubble/with-think.vue
@@ -1,0 +1,82 @@
+<script setup lang="tsx">
+import { BulbOutlined, DownOutlined, LoadingOutlined, UpOutlined, UserOutlined } from '@ant-design/icons-vue';
+import { Button, Space, Typography } from 'ant-design-vue';
+import { Bubble, type BubbleProps } from 'ant-design-x-vue';
+import markdownit from 'markdown-it';
+import { ref } from 'vue';
+
+defineOptions({ name: 'AXBubbleWithThink' });
+
+const md = markdownit({ html: true, breaks: true });
+
+const think = ref(false);
+const collapse = ref(false);
+const thinkContent = ref('');
+const answerContent = ref('');
+
+const renderMarkdown: BubbleProps['messageRender'] = (content) => (
+  <Typography>
+    <div v-html={md.render(content)} />
+  </Typography>
+);
+
+defineRender(() => {
+  return (
+    <Space direction="vertical" size="large">
+      <Button
+        disabled={think.value}
+        onClick={() => {
+          think.value = true
+          thinkContent.value += '> 好的，用户之前询问过我一些问题，我需要综合考虑，首先...';
+          answerContent.value = '';
+        }}
+      >
+        开始思考
+      </Button>
+      <Bubble
+        v-if={thinkContent.value}
+        avatar={{ icon: <UserOutlined /> }}
+        styles={{ footer: { marginTop: 0 } }}
+        content={
+          <Space>
+            <BulbOutlined />
+            <span>{think.value ? "思考中..." : "已深度思考"}</span>
+            <Button
+              type="text"
+              size="small"
+              style={{ background: 'transparent' }}
+              icon={collapse.value ? <UpOutlined /> : <DownOutlined />}
+              onClick={() => {
+                collapse.value = !collapse.value;
+              }}
+            />
+          </Space>
+        }
+        footer={
+          <Space direction="vertical">
+            <Bubble
+              v-show={!collapse.value}
+              variant="borderless"
+              typing
+              content={thinkContent.value}
+              messageRender={renderMarkdown}
+              onTypingComplete={() => {
+                think.value = false;
+                answerContent.value += '思考完毕，这是我的答案。';
+              }}
+            />
+            {think.value && <LoadingOutlined />}
+            <Bubble
+              variant="borderless"
+              style={{ marginTop: '-24px' }}
+              typing
+              content={answerContent}
+              messageRender={renderMarkdown}
+            />
+          </Space>
+        }
+      />
+    </Space>
+  );
+})
+</script>


### PR DESCRIPTION

<img width="617" alt="image" src="https://github.com/user-attachments/assets/f7490cfd-1e12-4a1e-9fef-ead94f416be6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the bubble component docs with a new "Deep Thinking" section featuring an interactive demo.
  
- **New Features**
  - Introduced interactive demo components that showcase deep thinking functionality with dynamic UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->