### PR TITLE
docs(Attachments): add all example for template 

### DIFF
--- a/docs/examples-setup/attachments/basic.vue
+++ b/docs/examples-setup/attachments/basic.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons-vue';
 import { message, Button, Flex, Switch, type UploadFile } from 'ant-design-vue';
-import { Attachments } from 'ant-design-x-vue';
-import { h, ref } from 'vue';
+import { Attachments, Sender } from 'ant-design-x-vue';
+import { computed, h, ref } from 'vue';
 
 defineOptions({ name: 'AXAttachmentBasic' });
 
@@ -10,12 +10,24 @@ defineOptions({ name: 'AXAttachmentBasic' });
 const fullScreenDrop = ref(false);
 const customContent = ref(true);
 const divRef = ref<HTMLDivElement>();
-  const [messageApi, contextHolder] = message.useMessage();
+const [messageApi, contextHolder] = message.useMessage();
 const handleChange = ({ file }: { file: UploadFile }) => {
   messageApi.info(`Mock upload: ${file.name}`);
 };
 
 const getDropContainer = () => (fullScreenDrop.value ? document.body : divRef.value);
+
+const attachmentsNode = computed(() => h(Attachments, {
+  beforeUpload: () => false,
+  onChange: handleChange,
+  placeholder: {
+    icon: h(CloudUploadOutlined),
+    title: 'Drag & Drop files here',
+    description: 'Support file type: image, video, audio, document, etc.',
+  },
+  children: customContent.value && h(Button, { type: 'text', icon: h(LinkOutlined) }),
+  getDropContainer,
+}));
 
 </script>
 
@@ -27,18 +39,9 @@ const getDropContainer = () => (fullScreenDrop.value ? document.body : divRef.va
       gap="middle"
       align="flex-start"
     >
-      <Attachments
-        :before-upload="() => false"
-        :on-change="handleChange"
-        :placeholder="{
-          icon: h(CloudUploadOutlined),
-          title: 'Drag & Drop files here',
-          description: 'Support file type: image, video, audio, document, etc.',
-        }"
-        :children="customContent && h(Button, { type: 'text', icon: h(LinkOutlined) })"
-        :get-drop-container="getDropContainer"
+      <Sender
+        :prefix="attachmentsNode"
       />
-
       <Switch
         v-model:checked="fullScreenDrop"
         checked-children="Full screen drop"

--- a/docs/examples-setup/attachments/files.vue
+++ b/docs/examples-setup/attachments/files.vue
@@ -1,6 +1,75 @@
 <script setup lang="ts">
-defineOptions({ name: 'AXAttachmentFilesSetup' });
+import { Flex } from 'ant-design-vue';
+import { Attachments } from 'ant-design-x-vue';
+
+defineOptions({ name: 'AXAttachmentFiles' });
+
+const filesList = [
+  {
+    uid: '1',
+    name: 'excel-file.xlsx',
+    size: 111111,
+  },
+  {
+    uid: '2',
+    name: 'word-file.docx',
+    size: 222222,
+  },
+  {
+    uid: '3',
+    name: 'image-file.png',
+    size: 333333,
+  },
+  {
+    uid: '4',
+    name: 'pdf-file.pdf',
+    size: 444444,
+  },
+  {
+    uid: '5',
+    name: 'ppt-file.pptx',
+    size: 555555,
+  },
+  {
+    uid: '6',
+    name: 'video-file.mp4',
+    size: 666666,
+  },
+  {
+    uid: '7',
+    name: 'audio-file.mp3',
+    size: 777777,
+  },
+  {
+    uid: '8',
+    name: 'zip-file.zip',
+    size: 888888,
+  },
+  {
+    uid: '9',
+    name: 'markdown-file.md',
+    size: 999999,
+    description: 'Custom description here',
+  },
+  {
+    uid: '10',
+    name: 'image-file.png',
+    thumbUrl: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+    url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+    size: 123456,
+  },
+];
 </script>
+
 <template>
-  <div>Needs to be supplemented.</div>
+  <Flex
+    vertical
+    gap="middle"
+  >
+    <Attachments.FileCard
+      v-for="(file, index) in filesList"
+      :key="index"
+      :item="file"
+    />
+  </Flex>
 </template>

--- a/docs/examples-setup/attachments/overflow.vue
+++ b/docs/examples-setup/attachments/overflow.vue
@@ -1,6 +1,72 @@
 <script setup lang="ts">
-defineOptions({ name: 'AXAttachmentOverflowSetup' });
+import { CloudUploadOutlined } from '@ant-design/icons-vue';
+import { Flex, Segmented, Switch } from 'ant-design-vue';
+import { Attachments, type AttachmentsProps } from 'ant-design-x-vue';
+import { ref, h, computed } from 'vue';
+
+defineOptions({ name: 'AXAttachmentOverflow' });
+
+const presetFiles: AttachmentsProps['items'] = Array.from({ length: 30 }).map((_, index) => ({
+  uid: String(index),
+  name: `file-${index}.jpg`,
+  status: 'done',
+  thumbUrl: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+  url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+}));
+
+const overflow = ref<AttachmentsProps['overflow']>('wrap');
+const items = ref<AttachmentsProps['items']>(presetFiles);
+const disabled = ref(false);
+
+// 使用计算属性来处理 items.length !== 0
+const hasItems = computed({
+  get: () => items.value.length !== 0,
+  set: (value) => {
+    items.value = value ? presetFiles : [];
+  }
+});
 </script>
+
 <template>
-  <div>Needs to be supplemented.</div>
+  <Flex
+    vertical
+    :gap="'middle'"
+  >
+    <Flex
+      :gap="'middle'"
+      :align="'center'"
+    >
+      <Segmented
+        v-model:value="overflow"
+        :options="[
+          { value: 'wrap', label: 'Wrap' },
+          { value: 'scrollX', label: 'Scroll X' },
+          { value: 'scrollY', label: 'Scroll Y' },
+        ]"
+        style="margin-inline-end: auto"
+      />
+      <Switch
+        v-model:checked="hasItems"
+        checked-children="Data"
+        un-checked-children="Data"
+      />
+      <Switch
+        v-model:checked="disabled"
+        checked-children="Disabled"
+        un-checked-children="Disabled"
+      />
+    </Flex>
+    <Attachments
+      :overflow="overflow"
+      :items="items"
+      :before-upload="() => false"
+      :placeholder="{
+        icon: h(CloudUploadOutlined),
+        title: 'Click or Drop files here',
+        description: 'Support file type: image, video, audio, document, etc.',
+      }"
+      :disabled="disabled"
+      @change="(info) => items = info.fileList"
+    />
+  </Flex>
 </template>

--- a/docs/examples-setup/attachments/with-sender.vue
+++ b/docs/examples-setup/attachments/with-sender.vue
@@ -1,6 +1,70 @@
 <script setup lang="ts">
-defineOptions({ name: 'AXAttachmentWithSenderSetup' });
+import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons-vue';
+import { App, Button, Flex, Badge } from 'ant-design-vue';
+import { Attachments, Sender } from 'ant-design-x-vue';
+import { computed, ref, h } from 'vue';
+
+defineOptions({ name: 'AXAttachmentWithSender' });
+
+const open = ref(true);
+const items = ref([]);
+const text = ref('');
+
+const senderRef = ref<InstanceType<typeof Sender>>(null);
+
+const senderHeader = computed(() => 
+  h(Sender.Header, {
+    title: "Attachments",
+    styles: {
+      content: {
+        padding: 0,
+      },
+    },
+    open: open.value,
+    onOpenChange: (v: boolean) => open.value = v,
+    forceRender: true
+  }, {
+    default: () => h(Attachments, {
+      beforeUpload: () => false,
+      items: items.value,
+      onChange: ({ fileList }: { fileList: any[] }) => items.value = fileList,
+      placeholder: (type: string) => type === 'drop'
+        ? { title: 'Drop file here' }
+        : {
+            icon: h(CloudUploadOutlined),
+            title: 'Upload files',
+            description: 'Click or drag files to this area to upload',
+          },
+      getDropContainer: () => senderRef.value?.nativeElement
+    })
+  })
+);
+
+const badgeNode = computed(() => 
+  h(Badge, { dot: items.value.length > 0 && !open.value }, {
+    default: () => h(Button, {
+      onClick: () => open.value = !open.value,
+      icon: h(LinkOutlined)
+    })
+  })
+);
 </script>
+
 <template>
-  <div>Needs to be supplemented.</div>
+  <Flex
+    style="min-height: 250px"
+    align="flex-end"
+  >
+    <Sender
+      ref="senderRef"
+      :header="senderHeader"
+      :prefix="badgeNode"
+      :value="text"
+      @change="v => text.value = v"
+      @submit="() => {
+        items.value = [];
+        text.value = '';
+      }"
+    />
+  </Flex>
 </template>

--- a/docs/examples/attachments/with-sender.vue
+++ b/docs/examples/attachments/with-sender.vue
@@ -53,7 +53,7 @@ const Demo = () => {
   ))
 
   return (
-    <Flex style={{ minHeight: 250 }} align="flex-end">
+    <Flex style={{ minHeight: '250px' }} align="flex-end">
       <Sender
         ref={senderRef}
         header={senderHeader.value}


### PR DESCRIPTION
Attchments template example is done 🎉 #127 
<img width="893" alt="image" src="https://github.com/user-attachments/assets/8a7cbd08-fe9a-41ed-8d6a-befcec9cf93d" />
<img width="840" alt="image" src="https://github.com/user-attachments/assets/40666255-095a-4185-b3fc-9c7bc8241700" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated a new sender component to enhance attachment workflows.
	- Upgraded the attachment interfaces with dynamic layouts, improved file displays, and configurable overflow controls.
	- Streamlined file attachment management for a more intuitive user experience.

- **Style**
	- Refined component sizing to ensure a consistent and predictable layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->