### PR TITLE
fix(conversation): fixed display issue where long Conversation names would not be truncated

### DIFF
--- a/src/conversations/style/index.ts
+++ b/src/conversations/style/index.ts
@@ -75,6 +75,8 @@ const genConversationsStyle: GenerateStyle<ConversationsToken> = (token) => {
       // 会话名
       [`& ${componentCls}-label`]: {
         flex: 1,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
         color: token.colorText,
       },
       // 会话操作菜单


### PR DESCRIPTION
Before：
<img width="1669" alt="image" src="https://github.com/user-attachments/assets/ab3d8091-a571-4d09-95d9-7b3893cead42" />

After：
<img width="1669" alt="image" src="https://github.com/user-attachments/assets/8ad3aac0-1377-4020-b0f5-01477d83c245" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the conversation label appearance to ensure that overflowing text is automatically truncated with an ellipsis for a cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->