### PR TITLE
feat: add resolver for unplugin-vue-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vue"
   ],
   "scripts": {
-    "build": "vite build && vue-tsc --project ./tsconfig.build.json",
+    "build": "vite build && vue-tsc --project ./tsconfig.build.json && tsc resolver/index.ts --outDir dist/resolver --declaration",
     "build:watch": "vite build --watch",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
@@ -42,7 +42,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.umd.js"
     },
-    "./dist/style.css": "./dist/style.css"
+    "./dist/style.css": "./dist/style.css",
+    "./resolver": {
+      "types": "./dist/typings/resolver/index.d.ts",
+      "import": "./dist/resolver/index.js"
+    }
   },
   "main": "./dist/index.umd.js",
   "module": "./dist/index.mjs",
@@ -126,6 +130,7 @@
     "@emotion/unitless": "^0.10.0",
     "classnames": "^2.5.1",
     "csstype": "^3.1.3",
+    "dist": "link:C:/code/ant-design-x-vue/dist",
     "stylis": "^4.3.4"
   },
   "packageManager": "pnpm@9.6.0"

--- a/resolver/README.md
+++ b/resolver/README.md
@@ -1,0 +1,70 @@
+# Ant Design X Vue Import Resolver
+
+English | [简体中文](./README.zh-CN.md)
+
+## Automatic Import
+
+This folder includes a resolver for [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components) that enables on-demand importing of Ant Design X Vue components.
+
+
+### Install Plugin
+
+```shell
+# npm
+npm i unplugin-vue-components  -D
+
+# yarn
+yarn add unplugin-vue-components -D
+
+# pnpm
+pnpm add unplugin-vue-components -D
+```
+
+### Vite
+
+```js
+// vite.config.js
+import vue from '@vitejs/plugin-vue'
+import components from 'unplugin-vue-components/vite'
+import { AntDesignXVueResolver } from 'ant-design-x-vue/resolver';
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    components({
+      resolvers: [AntDesignXVueResolver()]
+    })
+  ]
+})
+```
+
+### Vue CLI
+
+```js
+// vue.config.js
+const Components = require('unplugin-vue-components/webpack')
+const { AntDesignXVueResolver } = require('ant-design-x-vue/resolver')
+
+module.exports = {
+  configureWebpack: {
+    plugins: [
+      Components.default({
+        resolvers: [AntDesignXVueResolver()]
+      })
+    ]
+  }
+}
+```
+
+### Auto import
+```html
+<script setup>
+// auto import equal to
+// import { Bubble } from 'ant-design-x-vue'
+</script>
+
+<template>
+  <AXBubble content="Hello AI" />
+</template>
+```

--- a/resolver/README.zh-CN.md
+++ b/resolver/README.zh-CN.md
@@ -1,0 +1,71 @@
+# Ant Design X Vue Import Resolver
+
+[English](./README.md) | 简体中文
+
+## 自动引入
+
+此文件夹包含 [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components) 的解析器，用于实现 Ant Design X Vue 按需引入。
+
+
+### 安装插件
+
+```shell
+# npm
+npm i unplugin-vue-components  -D
+
+# yarn
+yarn add unplugin-vue-components -D
+
+# pnpm
+pnpm add unplugin-vue-components -D
+```
+
+### Vite 使用方法
+
+```js
+// vite.config.js
+import vue from '@vitejs/plugin-vue'
+import components from 'unplugin-vue-components/vite'
+import { AntDesignXVueResolver } from 'ant-design-x-vue/resolver';
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    components({
+      resolvers: [AntDesignXVueResolver()]
+    })
+  ]
+})
+```
+
+### Vue CLI 使用方法
+
+```js
+// vue.config.js
+const Components = require('unplugin-vue-components/webpack')
+const { AntDesignXVueResolver } = require('ant-design-x-vue/resolver')
+
+module.exports = {
+  configureWebpack: {
+    plugins: [
+      Components.default({
+        resolvers: [AntDesignXVueResolver()]
+      })
+    ]
+  }
+}
+```
+
+### 自动引入效果
+
+```html
+<script setup>
+// auto import equal to
+// import { Bubble } from 'ant-design-x-vue'
+</script>
+
+<template>
+  <AXBubble content="Hello AI" />
+</template>
+```

--- a/resolver/index.ts
+++ b/resolver/index.ts
@@ -1,0 +1,74 @@
+
+export interface AntDesignXResolverOptions {
+  /**
+   * exclude components that do not require automatic import
+   *
+   * @default []
+   */
+  exclude?: string[]
+
+  /**
+   * rename package
+   *
+   * @default 'ant-design-x-vue'
+   */
+  packageName?: string
+
+  /**
+   * customizable prefix for resolving components
+   * 
+   * @default 'AX'
+   */
+  prefix?: string
+}
+
+/**
+ * set of components that are contained in the package
+ */
+const primitiveNames = new Set<string>(['Attachments','Bubble'])
+
+function isAntdXVueComponent(name: string) {
+  return primitiveNames.has(name)
+}
+
+// currently unnecessary to add side effects
+// function getSideEffects(
+//  componentName: string,
+//  options: AntDesignXResolverOptions = {} 
+// ) {
+//   const { importStyle = true, packageName = 'ant-design-x-vue' } = options
+
+//   if (!importStyle) return
+
+//   return 
+// }
+
+export function AntDesignXVueResolver(
+  options: AntDesignXResolverOptions = {}
+) {
+  const {
+    prefix = 'AX',
+    packageName = 'ant-design-x-vue',
+    exclude = []
+  } = options
+
+  const resolverInfo = {
+    type: 'component',
+    resolve: (name: string) => {
+      if (!name.startsWith(prefix)) return
+
+      const componentName = name.slice(prefix.length)
+
+      if (
+        !isAntdXVueComponent(componentName) || exclude.includes(componentName)
+      ) return
+
+      return {
+        name: componentName,
+        from: packageName,
+        as: `${prefix}${componentName}`
+      }
+    }
+  }
+  return resolverInfo.resolve
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,6 +16,7 @@
     "paths": {
       "ant-design-x-vue": ["src/index.ts"],
       "ant-design-x-vue/*": ["src/*"],
+      "ant-design-x-vue/resolver/*": ["src/resolver/*"],
     }
   },
   "vueCompilerOptions": {


### PR DESCRIPTION
add unplugin-vue-components import resolver.

I had tested in Vite and written doc of it,
pls leave a message if there are any suggestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the auto-import resolver for Ant Design X Vue components, offering flexible component integration.
  
- **Documentation**
  - Added detailed setup guides (English and Simplified Chinese) for seamless integration with popular build tools.
  
- **Chores**
  - Improved the build process and module configuration to ensure robust type support and module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->