### PR TITLE
feat(sender): add files param to the onPasteFile callback

### DIFF
--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -73,9 +73,9 @@ sender/sendStyle
 
 :::
 
-### 黏贴图片
+### 黏贴文件
 
-:::demo 配合 Attachments 进行黏贴文件上传。
+:::demo 使用 `onPasteFile` 获取黏贴的文件，配合 Attachments 进行文件上传。
 
 sender/pasteImage
 
@@ -114,6 +114,7 @@ sender/focus
 | onSubmit | 点击发送按钮的回调 | (message: string) => void | - | - |
 | onChange | 输入框值改变的回调 | (value: string, event?: FormEvent \| ChangeEvent ) => void | - | - |
 | onCancel | 点击取消按钮的回调 | () => void | - | - |
+| onPasteFile | 黏贴文件的回调 | (firstFile: File, files: FileList) => void | - | - |
 
 ```typescript | pure
 type SpeechConfig = {

--- a/docs/examples/sender/pasteImage.vue
+++ b/docs/examples/sender/pasteImage.vue
@@ -64,9 +64,11 @@ const Demo = () => {
         }
         value={text.value}
         onChange={v => text.value = v}
-        onPasteFile={(file) => {
-          attachmentsRef.value.current?.upload(file);
-          open.value = (true);
+        onPasteFile={(_, files) => {
+          for (const file of files) {
+            attachmentsRef.value.current?.upload(file);
+          }
+          open.value = true;
         }}
         onSubmit={() => {
           items.value = []

--- a/src/sender/Sender.vue
+++ b/src/sender/Sender.vue
@@ -198,10 +198,10 @@ const onInternalKeyPress: SenderProps['onKeyPress'] = (e) => {
 
 // ============================ Paste =============================
 const onInternalPaste: ClipboardEventHandler = (e) => {
-  // Get file
-  const file = e.clipboardData?.files[0];
-  if (file && onPasteFile) {
-    onPasteFile(file);
+  // Get files
+  const files = e.clipboardData?.files;
+  if (files?.length && onPasteFile) {
+    onPasteFile(files[0], files);
     e.preventDefault();
   }
 

--- a/src/sender/interface.ts
+++ b/src/sender/interface.ts
@@ -49,7 +49,7 @@ export interface SenderProps {
   onCancel?: VoidFunction;
   onKeyDown?: KeyboardEventHandler;
   onPaste?: ClipboardEventHandler;
-  onPasteFile?: (file: File) => void;
+  onPasteFile?: (firstFile: File, files: FileList) => void;
   components?: SenderComponents;
   styles?: {
     prefix?: CSSProperties;


### PR DESCRIPTION
onPasteFile 回调支持获取到黏贴的多个文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced paste functionality now supports multiple files, allowing users to upload several files in one action.
- **Documentation**
  - Updated user guides and API details to reflect the improved file paste behavior, including revised section titles and clearer callback descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->