### PR TITLE
fix(thought-chain): fix controlled mode not working

### DIFF
--- a/docs/component/thought-chain.md
+++ b/docs/component/thought-chain.md
@@ -42,6 +42,14 @@ thought-chain/collapsible
 
 :::
 
+### 受控模式
+
+:::demo `collapsible` 支持传入对象，开启受控模式
+
+thought-chain/controlled
+
+:::
+
 ### 客制化
 
 :::demo `items` 属性支持灵活的客制化配置，详情参考 `ThoughtChainItem` 定义

--- a/docs/examples-setup/thought-chain/controlled.vue
+++ b/docs/examples-setup/thought-chain/controlled.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+defineOptions({ name: 'AXThoughtChainControlledSetup' });
+</script>
+<template>
+  <div>Needs to be supplemented.</div>
+</template>

--- a/docs/examples/thought-chain/controlled.vue
+++ b/docs/examples/thought-chain/controlled.vue
@@ -1,0 +1,72 @@
+<script setup lang="tsx">
+import { Card, CheckboxGroup, Space, Typography } from 'ant-design-vue';
+import { ThoughtChain, type ThoughtChainProps } from 'ant-design-x-vue';
+import { cloneVNode, ref } from 'vue';
+
+defineOptions({ name: 'AXThoughtChainControlled' });
+
+const { Paragraph, Text } = Typography;
+
+const mockContent = (
+  <Typography>
+    <Paragraph>
+      In the process of internal desktop applications development, many different design specs and
+      implementations would be involved, which might cause designers and developers difficulties and
+      duplication and reduce the efficiency of development.
+    </Paragraph>
+    <Paragraph>
+      After massive project practice and summaries, Ant Design, a design language for background
+      applications, is refined by Ant UED Team, which aims to{' '}
+      <Text strong>
+        uniform the user interface specs for internal background projects, lower the unnecessary
+        cost of design differences and implementation and liberate the resources of design and
+        front-end development
+      </Text>
+    </Paragraph>
+  </Typography>
+);
+
+const expandedKeys = ref(['1']);
+
+const onExpand = (keys: string[]) => {
+  expandedKeys.value = keys;
+};
+
+const items: ThoughtChainProps['items'] = [
+  {
+    key: '1',
+    title: 'Click me to expand the content',
+    description: 'Collapsible',
+    content: cloneVNode(mockContent),
+  },
+  {
+    key: '2',
+    title: 'Click me to expand the content',
+    description: 'Collapsible',
+    content: cloneVNode(mockContent),
+  },
+];
+
+defineRender(() => {
+  return (
+    <Card style={{ width: '500px' }}>
+      <Space direction="vertical" size="large">
+        <CheckboxGroup
+          v-model:value={expandedKeys.value}
+          options={items.map((item) => ({
+            label: `item ${item.key}`,
+            value: item.key
+          }))}
+        />
+        <ThoughtChain
+          items={items}
+          collapsible={{
+            expandedKeys: expandedKeys.value,
+            onExpand,
+          }}
+        />
+      </Space>
+    </Card>
+  );
+});
+</script>

--- a/play/src/App.vue
+++ b/play/src/App.vue
@@ -1,11 +1,53 @@
 <script setup lang="ts">
-import {Bubble} from "ant-design-x-vue";
+import { Card, Typography } from 'ant-design-vue';
+import { ThoughtChain, type ThoughtChainProps } from 'ant-design-x-vue';
+import { cloneVNode, h } from 'vue';
+
+defineOptions({ name: 'AXThoughtChainCollapsibleSetup' });
+
+const { Paragraph, Text } = Typography;
+
+// 更推荐将 mockContent 封装成 SFC
+const mockContent = h(Typography, {}, () => [
+  h(
+    Paragraph,
+    {},
+    () =>
+      'In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development.',
+  ),
+  h(Paragraph, {}, () => [
+    'After massive project practice and summaries, Ant Design, a design language for background applications, is refined by Ant UED Team, which aims to ',
+    h(
+      Text,
+      { strong: true },
+      () =>
+        'uniform the user interface specs for internal background projects, lower the unnecessary cost of design differences and implementation and liberate the resources of design and front-end development',
+    ),
+  ]),
+]);
+
+const items: ThoughtChainProps['items'] = [
+  {
+    title: 'Click me to expand the content',
+    key: '1',
+    description: 'Collapsible',
+    content: cloneVNode(h(mockContent)),
+  },
+  {
+    title: 'Click me to expand the content',
+    key: '2',
+    description: 'Collapsible',
+    content: cloneVNode(h(mockContent)),
+  },
+];
 </script>
-
 <template>
-  <Bubble content="hello world" />
+  <Card :style="{ width: '500px' }">
+    <ThoughtChain
+      :items="items"
+      :collapsible="{
+        expandedKeys: ['1'], //固定值
+      }"
+    />
+  </Card>
 </template>
-
-<style scoped>
-
-</style>

--- a/play/src/App.vue
+++ b/play/src/App.vue
@@ -1,65 +1,11 @@
 <script setup lang="ts">
-import { Card, Typography } from 'ant-design-vue';
-import { ThoughtChain, type ThoughtChainProps } from 'ant-design-x-vue';
-import { cloneVNode, h, ref } from 'vue';
-
-defineOptions({ name: 'AXThoughtChainCollapsibleSetup' });
-
-const { Paragraph, Text } = Typography;
-
-// 更推荐将 mockContent 封装成 SFC
-const mockContent = h(Typography, {}, () => [
-  h(
-    Paragraph,
-    {},
-    () =>
-      'In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development.',
-  ),
-  h(Paragraph, {}, () => [
-    'After massive project practice and summaries, Ant Design, a design language for background applications, is refined by Ant UED Team, which aims to ',
-    h(
-      Text,
-      { strong: true },
-      () =>
-        'uniform the user interface specs for internal background projects, lower the unnecessary cost of design differences and implementation and liberate the resources of design and front-end development',
-    ),
-  ]),
-]);
-
-const items: ThoughtChainProps['items'] = [
-  {
-    title: 'Click me to expand the content',
-    key: '1',
-    description: 'Collapsible',
-    content: cloneVNode(h(mockContent)),
-  },
-  {
-    title: 'Click me to expand the content',
-    key: '2',
-    description: 'Collapsible',
-    content: cloneVNode(h(mockContent)),
-  },
-];
-
-const expandedKeys = ref(['1']);
-
-setTimeout(() => {
-  expandedKeys.value = ["2"]
-}, 3000);
-
-const onExpand = (keys) => {
-  // 注释这行代码，验证必须设置节点展示列表
-  expandedKeys.value = keys;
-};
+import {Bubble} from "ant-design-x-vue";
 </script>
+
 <template>
-  <Card :style="{ width: '500px' }">
-    <ThoughtChain
-      :items="items"
-      :collapsible="{
-        expandedKeys,
-        onExpand,
-      }"
-    />
-  </Card>
+  <Bubble content="hello world" />
 </template>
+
+<style scoped>
+
+</style>

--- a/play/src/App.vue
+++ b/play/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Card, Typography } from 'ant-design-vue';
 import { ThoughtChain, type ThoughtChainProps } from 'ant-design-x-vue';
-import { cloneVNode, h } from 'vue';
+import { cloneVNode, h, ref } from 'vue';
 
 defineOptions({ name: 'AXThoughtChainCollapsibleSetup' });
 
@@ -40,13 +40,25 @@ const items: ThoughtChainProps['items'] = [
     content: cloneVNode(h(mockContent)),
   },
 ];
+
+const expandedKeys = ref(['1']);
+
+setTimeout(() => {
+  expandedKeys.value = ["2"]
+}, 3000);
+
+const onExpand = (keys) => {
+  // 注释这行代码，验证必须设置节点展示列表
+  expandedKeys.value = keys;
+};
 </script>
 <template>
   <Card :style="{ width: '500px' }">
     <ThoughtChain
       :items="items"
       :collapsible="{
-        expandedKeys: ['1'], //固定值
+        expandedKeys,
+        onExpand,
       }"
     />
   </Card>

--- a/src/thought-chain/hooks/useCollapsible.ts
+++ b/src/thought-chain/hooks/useCollapsible.ts
@@ -1,6 +1,6 @@
-import type { MaybeRefOrGetter, Ref } from 'vue';
-import { computed, toValue, watch } from 'vue';
 import useState from '../../_util/hooks/use-state';
+import { computed, toValue, watch } from 'vue';
+import type { MaybeRefOrGetter, Ref } from 'vue';
 
 export type CollapsibleOptions = {
   /**
@@ -25,31 +25,26 @@ type UseCollapsible = (
   prefixCls?: string,
   rootPrefixCls?: string,
 ) => [
-  Ref<boolean>,
-  Ref<RequiredCollapsibleOptions['expandedKeys']>,
-  ((curKey: string) => void) | undefined,
-  // CSSMotionProps,
-];
+    Ref<boolean>,
+    Ref<RequiredCollapsibleOptions['expandedKeys']>,
+    ((curKey: string) => void) | undefined,
+    // CSSMotionProps,
+  ];
 
-const useCollapsible: UseCollapsible = (
-  collapsible,
-  prefixCls,
-  rootPrefixCls,
-) => {
+const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) => {
   // ============================ Collapsible ============================
   const collapsibleState = computed(() => {
     const _collapsible = toValue(collapsible);
-
     let baseConfig: RequiredCollapsibleOptions = {
       expandedKeys: [],
-      onExpand: () => {},
+      onExpand: () => { },
     };
     if (!_collapsible) {
       return {
         enableCollapse: false,
         customizeExpandedKeys: baseConfig.expandedKeys,
-        customizeOnExpand: baseConfig.onExpand,
-      };
+        customizeOnExpand: baseConfig.onExpand
+      }
     }
     if (typeof _collapsible === 'object') {
       baseConfig = { ...baseConfig, ..._collapsible };
@@ -63,22 +58,20 @@ const useCollapsible: UseCollapsible = (
   });
 
   // ============================ ExpandedKeys ============================
-  const [mergedExpandedKeys, setMergedExpandedKeys] = useState<
-    RequiredCollapsibleOptions['expandedKeys']
-  >(collapsibleState.value.customizeExpandedKeys);
+  const [mergedExpandedKeys, setMergedExpandedKeys] =
+    useState<RequiredCollapsibleOptions['expandedKeys']>(collapsibleState.value.customizeExpandedKeys);
 
   // ============================ Event ============================
   const onItemExpand = (curKey: string) => {
     if (!collapsibleState.value.enableCollapse) {
       return;
     }
-
     const keys = mergedExpandedKeys.value.includes(curKey)
       ? mergedExpandedKeys.value.filter((key) => key !== curKey)
       : [...mergedExpandedKeys.value, curKey];
 
     collapsibleState.value.customizeOnExpand?.(keys);
-    
+
     // 受控模式下，由监听函数设置节点展开/关闭状态
     if (typeof toValue(collapsible) !== 'object') {
       setMergedExpandedKeys(keys);
@@ -114,6 +107,6 @@ const useCollapsible: UseCollapsible = (
     onItemExpand,
     // collapseMotion,
   ];
-};
+}
 
 export default useCollapsible;

--- a/src/thought-chain/hooks/useCollapsible.ts
+++ b/src/thought-chain/hooks/useCollapsible.ts
@@ -66,6 +66,11 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
     if (!collapsibleState.value.enableCollapse) {
       return;
     }
+
+    if (typeof toValue(collapsible) !== "boolean" && !collapsibleState.value.customizeExpandedKeys.includes(curKey)) {
+      return
+    }
+
     const keys = mergedExpandedKeys.value.includes(curKey)
       ? mergedExpandedKeys.value.filter((key) => key !== curKey)
       : [...mergedExpandedKeys.value, curKey];

--- a/src/thought-chain/hooks/useCollapsible.ts
+++ b/src/thought-chain/hooks/useCollapsible.ts
@@ -1,6 +1,6 @@
-import useState from '../../_util/hooks/use-state';
-import { computed, toValue, watch } from 'vue';
-import type { MaybeRefOrGetter, Ref } from 'vue';
+import useState from "../../_util/hooks/use-state";
+import { computed, toValue, watch } from "vue";
+import type { MaybeRefOrGetter, Ref } from "vue";
 
 export type CollapsibleOptions = {
   /**
@@ -53,8 +53,8 @@ const useCollapsible: UseCollapsible = (collapsible, prefixCls, rootPrefixCls) =
     return {
       enableCollapse: true,
       customizeExpandedKeys: baseConfig.expandedKeys,
-      customizeOnExpand: baseConfig.onExpand,
-    };
+      customizeOnExpand: baseConfig.onExpand
+    }
   });
 
   // ============================ ExpandedKeys ============================


### PR DESCRIPTION
Close #211 .

expandedKeys 是固定值时，思维链处于受控模式，任何点击将不展开节点。只允许对 expandedKeys 设置的项操作展开/收起。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a demo showcasing controlled mode for the ThoughtChain component, allowing users to manage expanded items via checkboxes.
  - Added documentation explaining how to use the controlled mode with the `collapsible` property.
- **Documentation**
  - Expanded the ThoughtChain documentation with a new section and example for controlled mode usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->