### PR TITLE
docs(conversations): add conversations menu trigger setup demo

### DIFF
--- a/docs/examples-setup/conversations/menu-trigger.vue
+++ b/docs/examples-setup/conversations/menu-trigger.vue
@@ -1,6 +1,63 @@
 <script setup lang="ts">
+import { DeleteOutlined, EditOutlined, PlusSquareOutlined, StopOutlined } from '@ant-design/icons-vue';
+import { Conversations, theme, type ConversationsProps } from 'ant-design-x-vue';
+import { h } from 'vue';
+
 defineOptions({ name: 'AXConversationsMenuTriggerSetup' });
+
+const items: ConversationsProps['items'] = Array.from({ length: 4 }).map((_, index) => ({
+  key: `item${index + 1}`,
+  label: `Conversation Item ${index + 1}`,
+  disabled: index === 3,
+}));
+
+const { token } = theme.useToken();
+
+const style = {
+  width: '256px',
+  background: token.value.colorBgContainer,
+  borderRadius: token.value.borderRadius,
+};
+
+const menuConfig: ConversationsProps['menu'] = (conversation) => ({
+  trigger: (menuInfo) => h(
+    PlusSquareOutlined,
+    {
+      onClick: () => {
+        console.log(`Click ${conversation.key} - ${menuInfo.key}`);
+      } 
+    }
+  ),
+  items: [
+    {
+      label: 'Operation 1',
+      key: 'operation1',
+      icon: h(EditOutlined),
+    },
+    {
+      label: 'Operation 2',
+      key: 'operation2',
+      icon: h(StopOutlined),
+      disabled: true,
+    },
+    {
+      label: 'Operation 3',
+      key: 'operation3',
+      icon: h(DeleteOutlined),
+      danger: true,
+    },
+  ],
+  onClick: (menuInfo) => {
+    menuInfo.domEvent.stopPropagation();
+    console.log(`Click ${conversation.key} - ${menuInfo.key}`);
+  },
+});
 </script>
 <template>
-  <div>Needs to be supplemented.</div>
+  <Conversations
+    default-active-key="item1"
+    :menu="menuConfig"
+    :items="items"
+    :style="style"
+  />
 </template>


### PR DESCRIPTION
#127 添加conversations组件menu-trigger的setup例子

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new example demonstrating how to use the Conversations component with a custom menu trigger, including styled conversation items and interactive menu actions.
- **Documentation**
  - Updated documentation with a fully implemented Vue example to showcase menu customization in the Conversations component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->