### PR TITLE
docs:  Document add page icon

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -89,6 +89,9 @@ export default defineConfig({
   },
   title: "Ant Design X Vue",
   description: "Ant Design X For Vue",
+  head: [
+    ['link', { rel: 'icon', href: '/images/x-logo.svg' }],
+  ],
   appearance: 'dark',
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config


### PR DESCRIPTION
目前组件文档页面没有显示页面icon

![image](https://github.com/user-attachments/assets/c09ee6ab-30cf-452d-8678-e25735c4b3cd)

增加icon展示

![image](https://github.com/user-attachments/assets/85529bf1-2923-4760-94ab-b0d500a5eb42)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation site to include a custom favicon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->