### PR TITLE
fix(attachments): fix img style

### DIFF
--- a/src/attachments/style/fileCard.ts
+++ b/src/attachments/style/fileCard.ts
@@ -2,7 +2,7 @@ import type { AttachmentsToken } from '.';
 import type { GenerateStyle } from '../../theme/cssinjs-utils';
 
 const genFileCardStyle: GenerateStyle<AttachmentsToken> = (token) => {
-  const { componentCls, calc } = token;
+  const { componentCls, antCls, calc } = token;
 
   const cardCls = `${componentCls}-list-card`;
 
@@ -79,18 +79,24 @@ const genFileCardStyle: GenerateStyle<AttachmentsToken> = (token) => {
         width: cardHeight,
         height: cardHeight,
         lineHeight: 1,
+        display: 'flex',
+        alignItems: 'center',
 
         [`&:not(${cardCls}-status-error)`]: {
           border: 0,
         },
 
         // Img
-        img: {
+        [`${antCls}-image`]: {
           width: '100%',
           height: '100%',
-          verticalAlign: 'top',
-          objectFit: 'cover',
           borderRadius: 'inherit',
+
+          img: {
+            height: '100%',
+            objectFit: 'cover',
+            borderRadius: 'inherit',
+          },
         },
 
         // Mask


### PR DESCRIPTION
Close #267 .

Before:

<img width="623" alt="image" src="https://github.com/user-attachments/assets/a7e98284-d155-4d50-8c4f-c7cc4a35334e" />

After: 

<img width="531" alt="image" src="https://github.com/user-attachments/assets/138d4969-7ddf-49bf-b2fe-47f8d13c4943" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved image alignment and styling within file preview cards for better consistency with Ant Design image components. Images are now centered and display with enhanced fit and border radius.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->