### PR TITLE
fix(sender): fix loading btn icon prop

### DIFF
--- a/src/sender/components/LoadingButton.vue
+++ b/src/sender/components/LoadingButton.vue
@@ -19,6 +19,7 @@ defineRender(() => {
     // variant="text"
     disabled={disabled}
     shape={shape}
+    icon={icon}
     {...restProps}
     style={{ backgroundColor: 'transparent', color: token.value.colorPrimary }}
     class={classNames(`${context.value.prefixCls}-loading-button`)}


### PR DESCRIPTION
Close #282 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where icons were not displayed on action buttons within loading buttons. Icons now appear as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->