### PR TITLE
build: external import starting with ant-design-vue

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -29,7 +29,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: [...externals],
+      external: [...externals, /^ant-design-vue/],
       input: Object.fromEntries(
         globSync('src/**/*.*').filter(file => !file.includes('test')).map(file => [
           // 删除 `src/` 以及每个文件的扩展名: src/nested/foo.js => nested/foo

--- a/vite.config.umd.mts
+++ b/vite.config.umd.mts
@@ -27,7 +27,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: [...externals],
+      external: [...externals, /^ant-design-vue/],
       output: [
         {
           format: 'umd',


### PR DESCRIPTION
Clse #312 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to better handle external dependencies related to ant-design-vue, ensuring all submodules are correctly treated as external during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->