### PR TITLE
fix(Sender): 修复 setup 模式下 Sender 粘贴文件无效问题

### DIFF
--- a/docs/examples-setup/sender/pasteImage.vue
+++ b/docs/examples-setup/sender/pasteImage.vue
@@ -29,7 +29,7 @@ const getDropContainer = () => senderRef.value?.nativeElement;
 const pastFile = (_, files) => {
   console.log("past")
   for (const file of files) {
-    attachmentsRef.value?.current?.upload(file);
+    attachmentsRef.value?.upload(file);
   }
   open.value = true;
 }


### PR DESCRIPTION
发现文档里只修复了 jsx 模式下 Sender 粘贴文件无效问题，漏掉了 setup 的例子，特此修复了下

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the way file uploads are triggered when pasting images, resulting in a more direct and streamlined upload process for users. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->