### PR TITLE
fix(bubble): fix slots type

### DIFF
--- a/src/bubble/Bubble.vue
+++ b/src/bubble/Bubble.vue
@@ -37,14 +37,14 @@ const {
 
 const slots = defineSlots<{
   avatar?(): VNode;
-  header?(props?: {
+  header?(props: {
     content: BubbleContentType;
   }): VNode | string;
-  footer?(props?: {
+  footer?(props: {
     content: BubbleContentType;
   }): VNode | string;
   loading?(): VNode;
-  message?(props?: {
+  message?(props: {
     content: BubbleContentType;
   }): VNode | string;
 }>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated slot definitions to require the `props` parameter for header, footer, and message slots, ensuring consistent access to content data within custom slot implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->