### PR TITLE
feat(bubble): support slots for bubble list

### DIFF
--- a/docs/component/bubble.md
+++ b/docs/component/bubble.md
@@ -1,3 +1,7 @@
+<script>
+import { useStorage } from '@vueuse/core';
+const preferLocal = useStorage('antdx-docs-preference', 'tsx');
+</script>
 
 # Bubble 对话气泡
 
@@ -89,6 +93,16 @@ bubble/bubble-custom
 
 :::
 
+<span v-if="preferLocal === 'setup'">
+
+:::demo 还可以使用插槽：
+
+bubble/bubble-custom-slot
+
+:::
+
+</span>
+
 ### 自定义列表内容
 
 :::demo 自定义气泡列表内容，这对于个性化定制场景非常有用。
@@ -156,6 +170,16 @@ bubble/gpt-vis
 | autoScroll | 当内容更新时，自动滚动到最新位置。如果用户滚动，则会暂停自动滚动。 | boolean | true |  |
 | items | 气泡数据列表 | (BubbleProps & { key?: string \| number, role?: string })[] | - |  |
 | roles | 设置气泡默认属性，`items` 中的 `role` 会进行自动对应 | Record<string, BubbleProps> \| (bubble, index) => BubbleProps | - |  |
+
+### Bubble.List Slots
+
+| 插槽名 | 说明 | 类型 |
+| --- | --- | --- |
+| avatar | 头像 | \{ item: BubbleProps & \{ key?: string \| number, role?: string \} \} |
+| header | 头部面板 | \{ item: BubbleProps & \{ key?: string \| number, role?: string \} \} |
+| footer | 底部内容 | \{ item: BubbleProps & \{ key?: string \| number, role?: string \} \} |
+| loading | loading占位 | \{ item: BubbleProps & \{ key?: string \| number, role?: string \} \} |
+| message | 消息内容 | \{ item: BubbleProps & \{ key?: string \| number, role?: string \} \} |
 
 ## Semantic DOM
 

--- a/docs/examples-setup/bubble/bubble-custom-slot.vue
+++ b/docs/examples-setup/bubble/bubble-custom-slot.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import {
+  FrownOutlined,
+  SmileOutlined,
+  SyncOutlined,
+  UserOutlined,
+} from '@ant-design/icons-vue';
+import { BubbleList } from 'ant-design-x-vue';
+import { Avatar, Button, Flex, Space, Spin } from 'ant-design-vue';
+import type { BubbleListProps } from 'ant-design-x-vue';
+import { ref } from 'vue';
+
+defineOptions({ name: 'AXBubbleBubbleCustomSlotSetup' });
+
+const roles: BubbleListProps['roles'] = {
+  ai: {
+    placement: 'start',
+    typing: { step: 5, interval: 20 },
+    style: {
+      maxWidth: '600px',
+      marginInlineEnd: '44px',
+    },
+    styles: {
+      footer: {
+        width: '100%',
+      },
+    },
+  },
+  user: {
+    placement: 'end',
+  },
+};
+
+// const listRef = useTemplateRef<InstanceType<typeof BubbleList>>(null);
+const listRef = ref<InstanceType<typeof BubbleList>>(null);
+</script>
+
+<template>
+  <BubbleList
+    ref="listRef"
+    :style="{ maxHeight: '300px' }"
+    :roles="roles"
+    :items="[
+      {
+        key: 'welcome',
+        role: 'ai',
+        content: 'Mock welcome content. '.repeat(10),
+      },
+      {
+        key: 'ask',
+        role: 'user',
+        content: 'Mock user content.',
+      },
+      {
+        key: 'ai',
+        role: 'ai',
+        loading: true,
+      },
+    ]"
+  >
+    <template #loading="{ item }">
+      <Space v-if="item.role === 'ai'">
+        <Spin size="small" />
+        Custom loading...
+      </Space>
+    </template>
+    <template #avatar="{ item }">
+      <Avatar
+        v-if="item.role === 'ai'"
+        :style="{ background: '#fde3cf' }"
+      >
+        <template #icon>
+          <UserOutlined />
+        </template>
+      </Avatar>
+      <Avatar
+        v-if="item.role === 'user'"
+        :style="{ background: '#87d068' }"
+      >
+        <template #icon>
+          <UserOutlined />
+        </template>
+      </Avatar>
+    </template>
+    <template #footer="{ item }">
+      <Flex v-if="item.key === 'welcome'">
+        <Button
+          size="small"
+          type="text"
+          style="margin-inline-end: auto;"
+        >
+          <template #icon>
+            <SyncOutlined />
+          </template>
+        </Button>
+        <Button
+          size="small"
+          type="text"
+        >
+          <template #icon>
+            <SmileOutlined />
+          </template>
+        </Button>
+        <Button
+          size="small"
+          type="text"
+        >
+          <template #icon>
+            <FrownOutlined />
+          </template>
+        </Button>
+      </Flex>
+    </template>
+    <template #header="{ item }">
+      <div style="color: #999; font-size: 12px; text-align: center;">
+        Custom Header {{ item.role }}
+      </div>
+    </template>
+    <template #message="{ item }">
+      {{ item.role }}: {{ item.content }}
+    </template>
+  </BubbleList>
+</template>

--- a/docs/examples-setup/bubble/bubble-custom.vue
+++ b/docs/examples-setup/bubble/bubble-custom.vue
@@ -18,8 +18,8 @@ const roles: BubbleListProps['roles'] = {
     avatar: { icon: h(UserOutlined), style: { background: '#fde3cf' } },
     typing: { step: 5, interval: 20 },
     style: {
-      maxWidth: 600,
-      marginInlineEnd: 44,
+      maxWidth: '600px',
+      marginInlineEnd: '44px',
     },
     styles: {
       footer: {
@@ -42,7 +42,7 @@ const listRef = ref<InstanceType<typeof BubbleList>>(null);
 <template>
   <BubbleList
     ref="listRef"
-    :style="{ maxHeight: 300 }"
+    :style="{ maxHeight: '300px' }"
     :roles="roles"
     :items="[
       {

--- a/docs/examples/bubble/bubble-custom-slot.vue
+++ b/docs/examples/bubble/bubble-custom-slot.vue
@@ -1,0 +1,8 @@
+<script setup lang="tsx">
+
+defineRender(() => {
+  return (
+    <div>Non Impl</div>
+  );
+});
+</script>

--- a/docs/examples/bubble/bubble-custom.vue
+++ b/docs/examples/bubble/bubble-custom.vue
@@ -13,8 +13,8 @@ const roles: BubbleListProps['roles'] = {
     avatar: { icon: <UserOutlined />, style: { background: '#fde3cf' } },
     typing: { step: 5, interval: 20 },
     style: {
-      maxWidth: 600,
-      marginInlineEnd: 44,
+      maxWidth: '600px',
+      marginInlineEnd: '44px',
     },
     styles: {
       footer: {
@@ -41,7 +41,7 @@ defineRender(() => {
   return (
     <BubbleList
       ref={listRef}
-      style={{ maxHeight: 300 }}
+      style={{ maxHeight: '300px' }}
       roles={roles}
       items={[
         {

--- a/src/bubble/Bubble.vue
+++ b/src/bubble/Bubble.vue
@@ -116,12 +116,18 @@ const mergedCls = computed(() => [
   },
 ]);
 
+const isVNodeArray = (val: any) => Array.isArray(val) && val.every(isVNode);
+
 // ============================ Avatar ============================
 const avatarNode = computed(() => {
   if (slots.avatar) {
     return slots.avatar();
   }
-  return isVNode(avatar) ? avatar : <Avatar {...avatar} />;
+  return typeof avatar === 'function'
+    ? avatar()
+    : (isVNode(avatar) || isVNodeArray(avatar))
+      ? avatar
+      : <Avatar {...avatar} />;
 });
 
 // =========================== Content ============================

--- a/src/bubble/BubbleList.vue
+++ b/src/bubble/BubbleList.vue
@@ -9,7 +9,7 @@ import useDisplayData from './hooks/useDisplayData';
 import useListData from './hooks/useListData';
 import type { BubbleListProps } from './interface';
 import useStyle from './style';
-import { computed, type HTMLAttributes, mergeProps, onWatcherCleanup, ref, unref, useAttrs, watch, watchEffect, nextTick } from 'vue';
+import { computed, type HTMLAttributes, mergeProps, onWatcherCleanup, ref, unref, useAttrs, watch, watchEffect, nextTick, type VNode } from 'vue';
 import useState from '../_util/hooks/use-state';
 import type { AvoidValidation } from '../type-utility';
 import BubbleContextProvider from './context';
@@ -28,6 +28,24 @@ const {
   roles: rolesProp,
   ...restProps
 } = defineProps<BubbleListProps>();
+
+const slots = defineSlots<{
+  avatar?(props: {
+    item: BubbleListProps['items'][number];
+  }): VNode;
+  header?(props: {
+    item: BubbleListProps['items'][number];
+  }): VNode | string;
+  footer?(props: {
+    item: BubbleListProps['items'][number];
+  }): VNode | string;
+  loading?(props: {
+    item: BubbleListProps['items'][number];
+  }): VNode;
+  message?(props: {
+    item: BubbleListProps['items'][number];
+  }): VNode | string;
+}>();
 
 const domProps = pickAttrs(mergeProps(restProps, attrs), {
   attr: true,
@@ -147,6 +165,11 @@ defineRender(() => {
         {unref(displayData).map(({ key, onTypingComplete: onTypingCompleteBubble, ...bubble }) => (
           <Bubble
             {...bubble}
+            avatar={slots.avatar ? () => slots.avatar?.({ item: { key, ...bubble } }) : bubble.avatar}
+            header={slots.header?.({ item: { key, ...bubble } }) ?? bubble.header}
+            footer={slots.footer?.({ item: { key, ...bubble } }) ?? bubble.footer}
+            loadingRender={slots.loading ? () => slots.loading({ item: { key, ...bubble } }) : bubble.loadingRender}
+            content={slots.message?.({ item: { key, ...bubble } }) ?? bubble.content}
             key={key}
             // 用于更新滚动的ref
             ref={(node) => {

--- a/src/bubble/interface.ts
+++ b/src/bubble/interface.ts
@@ -32,7 +32,7 @@ export interface BubbleProps<ContentType extends BubbleContentType = string> ext
   rootClassName?: string;
   styles?: Partial<Record<SemanticType, CSSProperties>>;
   classNames?: Partial<Record<SemanticType, string>>;
-  avatar?: Partial<_AvatarProps> | VNode;
+  avatar?: Partial<_AvatarProps> | VNode | (() => VNode);
   placement?: 'start' | 'end';
   loading?: boolean;
   typing?: AvoidValidation<TypingOption | boolean>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing various parts of chat bubbles (avatar, header, footer, loading, message) via new scoped slots in the bubble list component.
  - Avatars in chat bubbles can now be provided as functions or arrays of nodes, allowing for more flexible rendering.

- **Documentation**
  - Enhanced Bubble component documentation to detail available slots and their usage.
  - Added a dynamic demo showcasing slot customization based on user preference.
  - Updated API documentation to explicitly describe slot options for the bubble list.
  - Introduced new example components demonstrating customized chat bubble usage with role-based styling and slot content.

- **Style**
  - Updated style definitions to use explicit CSS units for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->