### PR TITLE
feat(sender): add speech custom icon support

### DIFF
--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -45,6 +45,18 @@ sender/speech
 
 </ClientOnly>
 
+### 语音输入图标
+
+<ClientOnly>
+
+:::demo 调整语音输入显示的图标，包含正在录音的图标。
+
+sender/speechIcon
+
+:::
+
+</ClientOnly>
+
 ### 自定义语音输入
 
 <ClientOnly>

--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -155,28 +155,31 @@ sender/focus
 
 ### SenderProps
 
-| 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| actions | 自定义按钮，当不需要默认操作按钮时，可以设为 `actions={false}` | VNode \| (oriNode, info: \{ components: ActionsComponents \}) => VNode | - | - |
-| allowSpeech | 是否允许语音输入 | boolean \| SpeechConfig | false | - |
-| classNames | 样式类名 | [见下](#semantic-dom) | - | - |
-| components | 自定义组件 | Record<'input', ComponentType> | - | - |
-| defaultValue | 输入框默认值 | string | - | - |
-| disabled | 是否禁用 | boolean | false | - |
-| loading | 是否加载中 | boolean | false | - |
-| header | 头部面板 | VNode \| () => VNode | - | - |
-| prefix | 前缀内容 | VNode \| () => VNode | - | - |
-| footer | 底部内容 | ReactNode \| (info: \{ components: ActionsComponents \}) => ReactNode | - | - |
-| readOnly | 是否让输入框只读 | boolean | false | - |
-| rootClassName | 根元素样式类 | string | - | - |
-| styles | 语义化定义样式 | [见下](#semantic-dom) | - | - |
-| submitType | 提交模式 | SubmitType | `enter` \| `shiftEnter` | - |
-| value(v-model) | 输入框值 | string | - | - |
-| onSubmit | 点击发送按钮的回调 | (message: string) => void | - | - |
-| onChange | 输入框值改变的回调 | (value: string, event?: FormEvent \| ChangeEvent ) => void | - | - |
-| onCancel | 点击取消按钮的回调 | () => void | - | - |
-| onPasteFile | 黏贴文件的回调 | (firstFile: File, files: FileList) => void | - | - |
-| autoSize | 自适应内容高度，可设置为 true \| false 或对象：\{ minRows: 2, maxRows: 6 \} | boolean \| \{ minRows?: number; maxRows?: number \} | \{ maxRows: 8 \} | - |
+| 属性               | 说明                                                                        | 类型                                                                   | 默认值                  | 版本 |
+| ------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------- | ---- |
+| actions            | 自定义按钮，当不需要默认操作按钮时，可以设为 `actions={false}`              | VNode \| (oriNode, info: \{ components: ActionsComponents \}) => VNode | -                       | -    |
+| allowSpeech        | 是否允许语音输入                                                            | boolean \| SpeechConfig                                                | false                   | -    |
+| classNames         | 样式类名                                                                    | [见下](#semantic-dom)                                                  | -                       | -    |
+| components         | 自定义组件                                                                  | Record<'input', ComponentType>                                         | -                       | -    |
+| defaultValue       | 输入框默认值                                                                | string                                                                 | -                       | -    |
+| disabled           | 是否禁用                                                                    | boolean                                                                | false                   | -    |
+| loading            | 是否加载中                                                                  | boolean                                                                | false                   | -    |
+| header             | 头部面板                                                                    | VNode \| () => VNode                                                   | -                       | -    |
+| prefix             | 前缀内容                                                                    | VNode \| () => VNode                                                   | -                       | -    |
+| footer             | 底部内容                                                                    | ReactNode \| (info: \{ components: ActionsComponents \}) => ReactNode  | -                       | -    |
+| readOnly           | 是否让输入框只读                                                            | boolean                                                                | false                   | -    |
+| rootClassName      | 根元素样式类                                                                | string                                                                 | -                       | -    |
+| styles             | 语义化定义样式                                                              | [见下](#semantic-dom)                                                  | -                       | -    |
+| submitType         | 提交模式                                                                    | SubmitType                                                             | `enter` \| `shiftEnter` | -    |
+| value(v-model)     | 输入框值                                                                    | string                                                                 | -                       | -    |
+| onSubmit           | 点击发送按钮的回调                                                          | (message: string) => void                                              | -                       | -    |
+| onChange           | 输入框值改变的回调                                                          | (value: string, event?: FormEvent \| ChangeEvent ) => void             | -                       | -    |
+| onCancel           | 点击取消按钮的回调                                                          | () => void                                                             | -                       | -    |
+| onPasteFile        | 黏贴文件的回调                                                              | (firstFile: File, files: FileList) => void                             | -                       | -    |
+| autoSize           | 自适应内容高度，可设置为 true \| false 或对象：\{ minRows: 2, maxRows: 6 \} | boolean \| \{ minRows?: number; maxRows?: number \}                    | \{ maxRows: 8 \}        | -    |
+| audioIcon          | 自定义语音输入图标                                                          | VNode                                                                  | AudioOutlined           | -    |
+| audioDisabledIcon  | 自定义麦克风禁用时语音输入图标                                              | VNode                                                                  | AudioMutedOutlined      | -    |
+| audioRecordingIcon | 自定义语音输入时的图标                                                      | VNode                                                                  | RecordingIcon（内部实现，非 `@ant-design/icons-vue`）           | -    |
 
 ```typescript | pure
 type SpeechConfig = {
@@ -198,31 +201,31 @@ type ActionsComponents = {
 
 ### Sender Slots
 
-| 插槽名   | 说明    | 类型 |
-| ------- | ------ | ---- |
-| header  | 头部面板 | -   |
-| prefix  | 前缀内容 | _   |
+| 插槽名  | 说明     | 类型                                                                                                                                                                                                  |
+| ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| header  | 头部面板 | -                                                                                                                                                                                                     |
+| prefix  | 前缀内容 | _                                                                                                                                                                                                     |
 | actions | 操作按钮 | \{ ori: VNode; info: \{ components: \{ SendButton: InstanceType\<Button\>; ClearButton: InstanceType\<Button\>; LoadingButton: InstanceType\<Button\>; SpeechButton: InstanceType\<Button\>; \} \} \} |
-| footer  | 底部内容 | \{ info: \{ components: \{ SendButton: InstanceType\<Button\>; ClearButton: InstanceType\<Button\>; LoadingButton: InstanceType\<Button\>; SpeechButton: InstanceType\<Button\>; \} \} \}              |
+| footer  | 底部内容 | \{ info: \{ components: \{ SendButton: InstanceType\<Button\>; ClearButton: InstanceType\<Button\>; LoadingButton: InstanceType\<Button\>; SpeechButton: InstanceType\<Button\>; \} \} \}             |
 
 #### Sender Ref
 
-| 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| nativeElement | 外层容器 | `HTMLDivElement` | - | - |
-| focus | 获取焦点 | (option?: { preventScroll?: boolean, cursor?: 'start' \| 'end' \| 'all' }) | - | - |
-| blur | 取消焦点 | () => void | - | - |
+| 属性          | 说明     | 类型                                                                       | 默认值 | 版本 |
+| ------------- | -------- | -------------------------------------------------------------------------- | ------ | ---- |
+| nativeElement | 外层容器 | `HTMLDivElement`                                                           | -      | -    |
+| focus         | 获取焦点 | (option?: { preventScroll?: boolean, cursor?: 'start' \| 'end' \| 'all' }) | -      | -    |
+| blur          | 取消焦点 | () => void                                                                 | -      | -    |
 
 ### Sender.Header
 
-| 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| children | 面板内容 | VNode | - | - |
-| closable | 是否可关闭 | boolean | true | - |
-| forceRender | 强制渲染，在初始化便需要 ref 内部元素时使用 | boolean | false | - |
-| open | 是否展开 | boolean | - | - |
-| title | 标题 | VNode | - | - |
-| onOpenChange | 展开状态改变的回调 | (open: boolean) => void | - | - |
+| 属性         | 说明                                        | 类型                    | 默认值 | 版本 |
+| ------------ | ------------------------------------------- | ----------------------- | ------ | ---- |
+| children     | 面板内容                                    | VNode                   | -      | -    |
+| closable     | 是否可关闭                                  | boolean                 | true   | -    |
+| forceRender  | 强制渲染，在初始化便需要 ref 内部元素时使用 | boolean                 | false  | -    |
+| open         | 是否展开                                    | boolean                 | -      | -    |
+| title        | 标题                                        | VNode                   | -      | -    |
+| onOpenChange | 展开状态改变的回调                          | (open: boolean) => void | -      | -    |
 
 ## Semantic DOM
 

--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -1,4 +1,3 @@
-
 # Sender 输入框
 
 用于聊天的输入框组件。
@@ -155,31 +154,28 @@ sender/focus
 
 ### SenderProps
 
-| 属性               | 说明                                                                        | 类型                                                                   | 默认值                  | 版本 |
-| ------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------- | ---- |
-| actions            | 自定义按钮，当不需要默认操作按钮时，可以设为 `actions={false}`              | VNode \| (oriNode, info: \{ components: ActionsComponents \}) => VNode | -                       | -    |
-| allowSpeech        | 是否允许语音输入                                                            | boolean \| SpeechConfig                                                | false                   | -    |
-| classNames         | 样式类名                                                                    | [见下](#semantic-dom)                                                  | -                       | -    |
-| components         | 自定义组件                                                                  | Record<'input', ComponentType>                                         | -                       | -    |
-| defaultValue       | 输入框默认值                                                                | string                                                                 | -                       | -    |
-| disabled           | 是否禁用                                                                    | boolean                                                                | false                   | -    |
-| loading            | 是否加载中                                                                  | boolean                                                                | false                   | -    |
-| header             | 头部面板                                                                    | VNode \| () => VNode                                                   | -                       | -    |
-| prefix             | 前缀内容                                                                    | VNode \| () => VNode                                                   | -                       | -    |
-| footer             | 底部内容                                                                    | ReactNode \| (info: \{ components: ActionsComponents \}) => ReactNode  | -                       | -    |
-| readOnly           | 是否让输入框只读                                                            | boolean                                                                | false                   | -    |
-| rootClassName      | 根元素样式类                                                                | string                                                                 | -                       | -    |
-| styles             | 语义化定义样式                                                              | [见下](#semantic-dom)                                                  | -                       | -    |
-| submitType         | 提交模式                                                                    | SubmitType                                                             | `enter` \| `shiftEnter` | -    |
-| value(v-model)     | 输入框值                                                                    | string                                                                 | -                       | -    |
-| onSubmit           | 点击发送按钮的回调                                                          | (message: string) => void                                              | -                       | -    |
-| onChange           | 输入框值改变的回调                                                          | (value: string, event?: FormEvent \| ChangeEvent ) => void             | -                       | -    |
-| onCancel           | 点击取消按钮的回调                                                          | () => void                                                             | -                       | -    |
-| onPasteFile        | 黏贴文件的回调                                                              | (firstFile: File, files: FileList) => void                             | -                       | -    |
-| autoSize           | 自适应内容高度，可设置为 true \| false 或对象：\{ minRows: 2, maxRows: 6 \} | boolean \| \{ minRows?: number; maxRows?: number \}                    | \{ maxRows: 8 \}        | -    |
-| audioIcon          | 自定义语音输入图标                                                          | VNode                                                                  | AudioOutlined           | -    |
-| audioDisabledIcon  | 自定义麦克风禁用时语音输入图标                                              | VNode                                                                  | AudioMutedOutlined      | -    |
-| audioRecordingIcon | 自定义语音输入时的图标                                                      | VNode                                                                  | RecordingIcon（内部实现，非 `@ant-design/icons-vue`）           | -    |
+| 属性           | 说明                                                                        | 类型                                                                   | 默认值                  | 版本 |
+| -------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------- | ---- |
+| actions        | 自定义按钮，当不需要默认操作按钮时，可以设为 `actions={false}`              | VNode \| (oriNode, info: \{ components: ActionsComponents \}) => VNode | -                       | -    |
+| allowSpeech    | 是否允许语音输入                                                            | boolean \| SpeechConfig                                                | false                   | -    |
+| classNames     | 样式类名                                                                    | [见下](#semantic-dom)                                                  | -                       | -    |
+| components     | 自定义组件                                                                  | Record<'input', ComponentType>                                         | -                       | -    |
+| defaultValue   | 输入框默认值                                                                | string                                                                 | -                       | -    |
+| disabled       | 是否禁用                                                                    | boolean                                                                | false                   | -    |
+| loading        | 是否加载中                                                                  | boolean                                                                | false                   | -    |
+| header         | 头部面板                                                                    | VNode \| () => VNode                                                   | -                       | -    |
+| prefix         | 前缀内容                                                                    | VNode \| () => VNode                                                   | -                       | -    |
+| footer         | 底部内容                                                                    | ReactNode \| (info: \{ components: ActionsComponents \}) => ReactNode  | -                       | -    |
+| readOnly       | 是否让输入框只读                                                            | boolean                                                                | false                   | -    |
+| rootClassName  | 根元素样式类                                                                | string                                                                 | -                       | -    |
+| styles         | 语义化定义样式                                                              | [见下](#semantic-dom)                                                  | -                       | -    |
+| submitType     | 提交模式                                                                    | SubmitType                                                             | `enter` \| `shiftEnter` | -    |
+| value(v-model) | 输入框值                                                                    | string                                                                 | -                       | -    |
+| onSubmit       | 点击发送按钮的回调                                                          | (message: string) => void                                              | -                       | -    |
+| onChange       | 输入框值改变的回调                                                          | (value: string, event?: FormEvent \| ChangeEvent ) => void             | -                       | -    |
+| onCancel       | 点击取消按钮的回调                                                          | () => void                                                             | -                       | -    |
+| onPasteFile    | 黏贴文件的回调                                                              | (firstFile: File, files: FileList) => void                             | -                       | -    |
+| autoSize       | 自适应内容高度，可设置为 true \| false 或对象：\{ minRows: 2, maxRows: 6 \} | boolean \| \{ minRows?: number; maxRows?: number \}                    | \{ maxRows: 8 \}        | -    |
 
 ```typescript | pure
 type SpeechConfig = {
@@ -187,6 +183,9 @@ type SpeechConfig = {
   // 交由开发者实现三方语音输入的功能。
   recording?: boolean;
   onRecordingChange?: (recording: boolean) => void;
+  audioIcon?: ButtonProps['icon'] | VNode;
+  audioDisabledIcon?: ButtonProps['icon'] | VNode;
+  audioRecordingIcon?: ButtonProps['icon'] | VNode;
 };
 ```
 

--- a/docs/examples-setup/sender/speechIcon.vue
+++ b/docs/examples-setup/sender/speechIcon.vue
@@ -16,11 +16,12 @@ const submit = () => {
   <App>
     <context-holder />
     <Sender
-      :allow-speech="true"
+      :allow-speech="{
+        audioIcon: h(SoundOutlined),
+        audioDisabledIcon: h(SoundOutlined, { style: { color: 'gray' } }),
+        audioRecordingIcon: h(EllipsisOutlined)
+      }"
       :on-submit="submit"
-      :audio-icon="h(SoundOutlined)"
-      :audio-disabled-icon="h(SoundOutlined, { style: { color: 'gray' } })"
-      :audio-recording-icon="h(EllipsisOutlined)"
     />
   </App>
 </template>

--- a/docs/examples-setup/sender/speechIcon.vue
+++ b/docs/examples-setup/sender/speechIcon.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { h } from 'vue';
+import { App, message } from 'ant-design-vue';
+import { Sender } from 'ant-design-x-vue';
+import { SoundOutlined, EllipsisOutlined } from '@ant-design/icons-vue';
+
+defineOptions({ name: 'AXSenderSpeechIconSetup' });
+
+const [messageApi, contextHolder] = message.useMessage();
+
+const submit = () => {
+  messageApi.success('Send message successfully!');
+};
+</script>
+<template>
+  <App>
+    <context-holder />
+    <Sender
+      :allow-speech="true"
+      :on-submit="submit"
+      :audio-icon="h(SoundOutlined)"
+      :audio-disabled-icon="h(SoundOutlined, { style: { color: 'gray' } })"
+      :audio-recording-icon="h(EllipsisOutlined)"
+    />
+  </App>
+</template>

--- a/docs/examples/sender/speechIcon.vue
+++ b/docs/examples/sender/speechIcon.vue
@@ -11,13 +11,14 @@ const Demo = () => {
 
   return (
     <Sender
-      allowSpeech
+      allowSpeech={{
+        audioIcon: h(SoundOutlined),
+        audioDisabledIcon: h(SoundOutlined, { style: { color: 'gray' } }),
+        audioRecordingIcon: h(EllipsisOutlined)
+      }}
       onSubmit={() => {
         message.success('Send message successfully!');
       }}
-      audioIcon={h(SoundOutlined)}
-      audioDisabledIcon={h(SoundOutlined, { style: { color: 'gray' } })}
-      audioRecordingIcon={h(EllipsisOutlined)}
     />
   );
 };

--- a/docs/examples/sender/speechIcon.vue
+++ b/docs/examples/sender/speechIcon.vue
@@ -1,0 +1,33 @@
+<script setup lang="tsx">
+import { h } from 'vue';
+import { App } from 'ant-design-vue';
+import { Sender } from 'ant-design-x-vue';
+import { SoundOutlined, EllipsisOutlined } from '@ant-design/icons-vue';
+
+defineOptions({ name: 'AXSenderSpeechIcon' });
+
+const Demo = () => {
+  const { message } = App.useApp();
+
+  return (
+    <Sender
+      allowSpeech
+      onSubmit={() => {
+        message.success('Send message successfully!');
+      }}
+      audioIcon={h(SoundOutlined)}
+      audioDisabledIcon={h(SoundOutlined, { style: { color: 'gray' } })}
+      audioRecordingIcon={h(EllipsisOutlined)}
+    />
+  );
+};
+
+defineRender(() => {
+  return (
+    <App>
+      <Demo />
+    </App>
+  )
+});
+
+</script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7124,7 +7124,6 @@ snapshots:
       ant-design-vue: 4.2.6(vue@3.5.13(typescript@5.8.2))
       classnames: 2.5.1
       csstype: 3.1.3
-      npm-run-all2: 8.0.3
       stylis: 4.3.4
       vue: 3.5.13(typescript@5.8.2)
 

--- a/src/sender/Sender.vue
+++ b/src/sender/Sender.vue
@@ -63,9 +63,6 @@ const {
   onPaste,
   onPasteFile,
   autoSize = { maxRows: 8 },
-  audioIcon,
-  audioDisabledIcon,
-  audioRecordingIcon,
   ...rest
 } = defineProps<SenderProps>();
 

--- a/src/sender/Sender.vue
+++ b/src/sender/Sender.vue
@@ -248,7 +248,17 @@ const onContentMouseDown: MouseEventHandler = (e) => {
 const actionNode = computed(() => {
   let _actionNode: VNode | false = (
     <Flex class={`${actionListCls.value}-presets`}>
-      {allowSpeech && (<SpeechButton audioIcon={audioIcon} audioDisabledIcon={audioDisabledIcon} audioRecordingIcon={audioRecordingIcon} />)}
+      {allowSpeech && (
+        <SpeechButton
+          {...(typeof allowSpeech === 'object' ? 
+            { 
+              audioIcon: allowSpeech.audioIcon, 
+              audioDisabledIcon: allowSpeech.audioDisabledIcon, 
+              audioRecordingIcon: allowSpeech.audioRecordingIcon 
+            } : {}
+          )}
+        />
+      )}
       {/* Loading or Send */}
       {loading ? <LoadingButton /> : <SendButton />}
     </Flex>

--- a/src/sender/Sender.vue
+++ b/src/sender/Sender.vue
@@ -266,7 +266,6 @@ const actionNode = computed(() => {
   } else if (actions || actions === false) {
     _actionNode = actions;
   }
-  console.log('actionNode:', _actionNode);
   return _actionNode;
 });
 

--- a/src/sender/Sender.vue
+++ b/src/sender/Sender.vue
@@ -63,6 +63,9 @@ const {
   onPaste,
   onPasteFile,
   autoSize = { maxRows: 8 },
+  audioIcon,
+  audioDisabledIcon,
+  audioRecordingIcon,
   ...rest
 } = defineProps<SenderProps>();
 
@@ -245,7 +248,7 @@ const onContentMouseDown: MouseEventHandler = (e) => {
 const actionNode = computed(() => {
   let _actionNode: VNode | false = (
     <Flex class={`${actionListCls.value}-presets`}>
-      {allowSpeech && <SpeechButton />}
+      {allowSpeech && (<SpeechButton audioIcon={audioIcon} audioDisabledIcon={audioDisabledIcon} audioRecordingIcon={audioRecordingIcon} />)}
       {/* Loading or Send */}
       {loading ? <LoadingButton /> : <SendButton />}
     </Flex>
@@ -263,6 +266,7 @@ const actionNode = computed(() => {
   } else if (actions || actions === false) {
     _actionNode = actions;
   }
+  console.log('actionNode:', _actionNode);
   return _actionNode;
 });
 

--- a/src/sender/components/SpeechButton/index.vue
+++ b/src/sender/components/SpeechButton/index.vue
@@ -4,29 +4,36 @@ import { AudioMutedOutlined, AudioOutlined } from '@ant-design/icons-vue';
 import type { AntdButtonProps } from '../../interface';
 import ActionButton from '../ActionButton/index.vue';
 import { useActionButtonContextInject } from '../ActionButton/context';
-
 import RecordingIcon from './RecordingIcon.vue';
 import { computed } from 'vue';
 
 defineOptions({ name: 'AXSenderSpeechButton' });
 
-const { type = 'text', disabled = undefined, ...restProps} = defineProps<AntdButtonProps>();
+const { type = 'text',
+  disabled = undefined,
+  audioIcon = (<AudioOutlined />),
+  audioDisabledIcon = (<AudioMutedOutlined />),
+  audioRecordingIcon = undefined,
+  ...restProps
+} = defineProps<AntdButtonProps>();
 
 const context = useActionButtonContextInject();
+
 const { token } = theme.useToken();
 
 const speechRecording = computed(() => context.value.speechRecording);
+
 const prefixCls = computed(() => context.value.prefixCls);
 
 const icon = computed(() => {
 
   let myIcon;
   if (speechRecording.value) {
-    myIcon = <RecordingIcon className={`${prefixCls.value}-recording-icon`} />;
+    myIcon = audioRecordingIcon ? (audioRecordingIcon) : (<RecordingIcon className={`${prefixCls.value}-recording-icon`} />)
   } else if (context.value.onSpeechDisabled) {
-    myIcon = <AudioMutedOutlined />;
+    myIcon = audioDisabledIcon
   } else {
-    myIcon = <AudioOutlined />;
+    myIcon = audioIcon
   }
   return myIcon
 })

--- a/src/sender/interface.ts
+++ b/src/sender/interface.ts
@@ -17,7 +17,7 @@ export type ClipboardEventHandler = (e: ClipboardEvent) => void;
 
 export type ChangeEvent = Event & {
   target: {
-      value?: string | undefined;
+    value?: string | undefined;
   };
 }
 
@@ -86,6 +86,9 @@ export interface SenderProps {
   footer?: VNode | FooterRender;
   header?: VNode | (() => VNode);
   autoSize?: AvoidValidation<boolean | { minRows?: number; maxRows?: number }>;
+  audioIcon?: ButtonProps['icon'];
+  audioDisabledIcon?: ButtonProps['icon']
+  audioRecordingIcon?: ButtonProps['icon'];
 }
 
 export interface InputFocusOptions extends FocusOptions {
@@ -118,6 +121,9 @@ export interface SenderHeaderProps {
 
 export interface RecordingIconProps {
   className?: string;
+  audioIcon?: ButtonProps['icon'];
+  audioDisabledIcon?: ButtonProps['icon'];
+  audioRecordingIcon?: ButtonProps['icon'];
 }
 
 export interface ActionButtonContextProps {
@@ -152,6 +158,9 @@ export interface AntdButtonProps {
   title?: ButtonProps['title'];
   onClick?: ButtonProps['onClick'];
   onMousedown?: ButtonProps['onMousedown'];
+  audioIcon?: ButtonProps['icon'];
+  audioDisabledIcon?: ButtonProps['icon']
+  audioRecordingIcon?: ButtonProps['icon'];
 }
 
 export interface ActionButtonProps extends AntdButtonProps {

--- a/src/sender/interface.ts
+++ b/src/sender/interface.ts
@@ -86,9 +86,6 @@ export interface SenderProps {
   footer?: VNode | FooterRender;
   header?: VNode | (() => VNode);
   autoSize?: AvoidValidation<boolean | { minRows?: number; maxRows?: number }>;
-  audioIcon?: ButtonProps['icon'];
-  audioDisabledIcon?: ButtonProps['icon']
-  audioRecordingIcon?: ButtonProps['icon'];
 }
 
 export interface InputFocusOptions extends FocusOptions {
@@ -158,9 +155,9 @@ export interface AntdButtonProps {
   title?: ButtonProps['title'];
   onClick?: ButtonProps['onClick'];
   onMousedown?: ButtonProps['onMousedown'];
-  audioIcon?: ButtonProps['icon'];
-  audioDisabledIcon?: ButtonProps['icon']
-  audioRecordingIcon?: ButtonProps['icon'];
+  audioIcon?: ButtonProps['icon'] | VNode;
+  audioDisabledIcon?: ButtonProps['icon'] | VNode
+  audioRecordingIcon?: ButtonProps['icon'] | VNode;
 }
 
 export interface ActionButtonProps extends AntdButtonProps {

--- a/src/sender/useSpeech.ts
+++ b/src/sender/useSpeech.ts
@@ -11,7 +11,7 @@ if (!SpeechRecognition && typeof window !== 'undefined') {
 
 export type ControlledSpeechConfig = {
   recording?: boolean;
-  onRecordingChange: (recording: boolean) => void;
+  onRecordingChange?: (recording: boolean) => void;
   audioIcon?: ButtonProps['icon'];
   audioDisabledIcon?: ButtonProps['icon']
   audioRecordingIcon?: ButtonProps['icon'];

--- a/src/sender/useSpeech.ts
+++ b/src/sender/useSpeech.ts
@@ -1,3 +1,4 @@
+import { ButtonProps } from 'ant-design-vue';
 import useMergedState from '../_util/hooks/useMergedState';
 import { computed, ref, watchEffect, type MaybeRefOrGetter, toValue, onWatcherCleanup, type ComputedRef, type Ref } from 'vue';
 
@@ -11,6 +12,9 @@ if (!SpeechRecognition && typeof window !== 'undefined') {
 export type ControlledSpeechConfig = {
   recording?: boolean;
   onRecordingChange: (recording: boolean) => void;
+  audioIcon?: ButtonProps['icon'];
+  audioDisabledIcon?: ButtonProps['icon']
+  audioRecordingIcon?: ButtonProps['icon'];
 };
 
 export type AllowSpeech = boolean | ControlledSpeechConfig;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the voice input, disabled microphone, and recording icons in the Sender component.
  - Introduced new demo examples showcasing how to use and customize these audio state icons.

- **Documentation**
  - Updated Sender component documentation with a new demo section and detailed descriptions of the new icon customization props.
  - Improved formatting for API and props tables for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->