### PR TITLE
docs(xstream): fix documentation typos

### DIFF
--- a/docs/component/x-stream.md
+++ b/docs/component/x-stream.md
@@ -13,7 +13,7 @@
 常见的 `ReadableStream` 实例，如 `await fetch(...).body` 使用示例:
 
 ```js
-import { XStream } from '@ant-design/x';
+import { XStream } from 'ant-design-x-vue';
 
 async function request() {
   const response = await fetch();


### PR DESCRIPTION
### Code Changes
```tsx
// Before
import { XStream } from 'ant-design-x';

// After  
import { XStream } from 'ant-design-x-vue';
```

fix #376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the import statement in the example code to reference the correct package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->