### PR TITLE
feat: support conf compatible style

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -116,6 +116,10 @@ export default defineConfig({
           text: 'Ant Design X of Vue',
           link: '/development/introduce'
         },
+        {
+          text: '样式兼容',
+          link: '/development/compatible-style'
+        },
       ],
       '/component/': [
         {

--- a/docs/development/compatible-style.md
+++ b/docs/development/compatible-style.md
@@ -1,0 +1,20 @@
+# StyleProvider 样式兼容
+
+兼容旧版浏览器，请根据实际需求进行降级处理。
+
+## 使用说明
+
+`StyleProvider` 继承了 `antdv` 的 [`StyleProvider🔗`](https://www.antdv.com/docs/vue/compatible-style-cn)。
+
+如果您已经使用 `antdv` 的 `StyleProvider`，请对您的代码做如下变更：
+
+```diff
+- import { StyleProvider } from 'ant-design-vue';
++ import { StyleProvider } from 'ant-design-x-vue';
+
+  const App = () => (
+    <StyleProvider>
+      <YourApp />
+    </StyleProvider>
+  );
+```

--- a/src/_util/cssinjs/StyleContext.tsx
+++ b/src/_util/cssinjs/StyleContext.tsx
@@ -7,11 +7,13 @@ import {
   watch,
   shallowRef,
   getCurrentInstance,
+  h,
 } from 'vue';
 import CacheEntity from './Cache';
 import type { Linter } from './linters/interface';
 import type { Transformer } from './transformers/interface';
 import { arrayType, booleanType, objectType, someType, stringType, withInstall } from '../type';
+import { StyleProvider as AntdStyleProvider } from 'ant-design-vue';
 export const ATTR_TOKEN = 'data-token-hash';
 export const ATTR_MARK = 'data-css-hash';
 export const ATTR_CACHE_PATH = 'data-cache-path';
@@ -179,12 +181,17 @@ export const styleProviderProps = () => ({
 export type StyleProviderProps = Partial<ExtractPropTypes<ReturnType<typeof styleProviderProps>>>;
 export const StyleProvider = withInstall(
   defineComponent({
-    name: 'AStyleProvider',
+    name: 'AXStyleProvider',
     inheritAttrs: false,
     props: styleProviderProps(),
     setup(props, { slots }) {
       useStyleProvider(props);
-      return () => slots.default?.();
+      return () => h(
+        AntdStyleProvider,
+        // @ts-ignore
+        props,
+        () => slots.default?.()
+      );
     },
   }),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import type { App } from 'vue';
 
 import * as components from './components';
+import cssinjs from './_util/cssinjs';
 
 export * from './components';
 export * from './hooks';
 
 export * from './theme';
+export * from './_util/cssinjs';
 
 export const install = function (app: App) {
   Object.keys(components).forEach(key => {
@@ -15,6 +17,7 @@ export const install = function (app: App) {
       app.use(component);
     }
   });
+  app.use(cssinjs.StyleProvider);
   return app;
 };
 


### PR DESCRIPTION
未设置样式兼容：
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/f239d6c7-8801-4343-ac5e-21af5256d2d9" />

设置样式兼容：
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/f9f3ec8f-9760-4ca4-9cdf-55049bae33dd" />
```html
import { StyleProvider } from 'ant-design-x-vue' 

<StyleProvider hashPriority="high">
   // Your App
</StyleProvider>
```
