### PR TITLE
docs(sender): add custom input demo

### DIFF
--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -112,6 +112,14 @@ sender/footer
 
 :::
 
+### 自定义输入框
+
+:::demo 使用 `components.input` 自定义输入框。
+
+sender/custom-input
+
+:::
+
 ### 调整样式
 
 <ClientOnly>

--- a/docs/examples-setup/sender/custom-input.vue
+++ b/docs/examples-setup/sender/custom-input.vue
@@ -1,0 +1,6 @@
+<script lang="ts" setup>
+defineOptions({ name: 'AXSenderCustomInputSetup' })
+</script>
+<template>
+  <div>Need to be supplemented</div>
+</template>

--- a/docs/examples/sender/custom-input.vue
+++ b/docs/examples/sender/custom-input.vue
@@ -1,0 +1,65 @@
+<script lang="tsx" setup>
+import { Input } from 'ant-design-vue';
+import { textAreaProps } from 'ant-design-vue/es/input/inputProps';
+import { triggerFocus } from 'ant-design-vue/es/vc-input/utils/commonUtils';
+import { Sender } from 'ant-design-x-vue';
+import type { InputFocusOptions } from 'ant-design-x-vue/sender/interface';
+import { defineComponent, ref, shallowRef } from 'vue';
+
+defineOptions({ name: 'AXSenderCustomInput' });
+
+const value = ref<string>('');
+
+const MyInputTextArea = defineComponent({
+  name: 'MyInputTextArea',
+  props: textAreaProps(),
+  setup(props, { attrs, expose }) {
+    const textAreaRef = shallowRef();
+
+    const focus = (option?: InputFocusOptions) => {
+      triggerFocus(textAreaRef.value, option);
+    };
+
+    const blur = () => {
+      textAreaRef.value?.blur();
+    };
+
+    expose({
+      focus,
+      blur,
+    });
+
+    return () => (
+      <Input.TextArea
+        {...attrs}
+        {...props}
+        ref={textAreaRef}
+        style={{ minHeight: 100 }}
+        autoSize={{ minRows: 3, maxRows: 6 }}
+        showCount
+        maxlength={20}
+        placeholder="Type your message here..."
+      />
+    );
+  },
+});
+
+defineRender(() => {
+  return (
+    <Sender
+      value={value.value}
+      onChange={(v) => {
+        value.value = v;
+      }}
+      placeholder="Press Enter to send message"
+      components={{
+        input: MyInputTextArea,
+      }}
+      onSubmit={(message) => {
+        console.log('Submitted:', message);
+        value.value = '';
+      }}
+    />
+  );
+})
+</script>


### PR DESCRIPTION
利用自定义input功能实现一个带字数统计和字数限制的输入框

<img width="697" alt="image" src="https://github.com/user-attachments/assets/dd42aaf5-76ad-492d-ba07-fb413b68b857" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation and demo showcasing how to customize the input box for the Sender component.
  * Introduced a custom input example with a multi-line text area, character count, and submission handling for the Sender component.

* **Documentation**
  * Updated Sender component docs with a new section explaining custom input integration and referencing the new demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->