### PR TITLE
feat(attachments): support multiple files upload

### DIFF
--- a/docs/component/attachments.md
+++ b/docs/component/attachments.md
@@ -1,3 +1,4 @@
+
 # Attachments 输入附件
 
 用于展示一组附件信息集合。
@@ -68,18 +69,18 @@ attachments/files
 
 继承 antdv [Upload](https://www.antdv.com/components/upload-cn) 属性。
 
-| 属性             | 说明                                                                       | 类型                                                               | 默认值 | 版本 |
-| ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------ | ---- |
-| classNames       | 自定义样式类名，[见下](#semantic-dom)                                      | Record<string, string>                                             | -      | -    |
-| disabled         | 是否禁用                                                                   | boolean                                                            | false  | -    |
-| getDropContainer | 设置拖拽时，可以释放文件的区域                                             | () => HTMLElement                                                  | -      | -    |
-| items            | 附件列表，同 Upload `fileList`                                             | Attachment[]                                                       | -      | -    |
-| overflow         | 文件列表超出时样式                                                         | 'wrap' \| 'scrollX' \| 'scrollY'                                   | -      | -    |
-| placeholder      | 没有文件时的占位信息                                                       | PlaceholderType \| ((type: 'inline' \| 'drop') => PlaceholderType) | -      | -    |
-| rootClassName    | 根节点的样式类名                                                           | string                                                             | -      | -    |
-| rootStyle        | 根节点的样式对象                                                           | CSSProperties                                                      | -      | -    |
-| styles           | 自定义样式对象，[见下](#semantic-dom)                                      | Record<string, CSSProperties>                                      | -      | -    |
-| imageProps       | 图片属性，同 antdv [Image](https://www.antdv.com/components/image-cn) 属性 | ImageProps                                                         | -      | -    |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| classNames | 自定义样式类名，[见下](#semantic-dom) | Record<string, string> | - | - |
+| disabled | 是否禁用 | boolean | false | - |
+| getDropContainer | 设置拖拽时，可以释放文件的区域 | () => HTMLElement | - | - |
+| items | 附件列表，同 Upload `fileList` | Attachment[] | - | - |
+| overflow | 文件列表超出时样式 | 'wrap' \| 'scrollX' \| 'scrollY' | - | - |
+| placeholder | 没有文件时的占位信息 | PlaceholderType \| ((type: 'inline' \| 'drop') => PlaceholderType) | - | - |
+| rootClassName | 根节点的样式类名 | string | - | - |
+| rootStyle | 根节点的样式对象 | CSSProperties | - | - |
+| styles | 自定义样式对象，[见下](#semantic-dom) | Record<string, CSSProperties> | - | - |
+| imageProps | 图片属性，同 antdv [Image](https://www.antdv.com/components/image-cn) 属性 | ImageProps | - | - |
 
 ```tsx | pure
 interface PlaceholderType {
@@ -91,23 +92,23 @@ interface PlaceholderType {
 
 ### Attachments Slots
 
-| 插槽名      | 说明                 | 类型                           |
-| ----------- | -------------------- | ------------------------------ |
+| 插槽名 | 说明 | 类型 |
+| --- | --- | --- |
 | placeholder | 没有文件时的占位信息 | \{ type: "inline" \| "drop" \} |
 
 ### Attachments Expose
 
-| 属性          | 说明             | 类型                                       | 版本 |
-| ------------- | ---------------- | ------------------------------------------ | ---- |
-| nativeElement | 获取原生节点     | HTMLElement                                | -    |
+| 属性          | 说明             | 类型                 | 版本 |
+| ------------- | ---------------- | -------------------- | ---- |
+| nativeElement | 获取原生节点     | HTMLElement          | -    |
 | upload        | 手工调用上传文件 | (file: File \| File[] \| FileList) => void | -    |
 
 ### Attachments.FileCard Props
 
-| 属性     | 说明                                                                                                                     | 类型                                     | 默认值 | 版本 |
-| -------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------ | ---- |
-| item     | 附件，同 Upload `UploadFile`                                                                                             | Attachment                               | -      | -    |
-| onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean \| Promise | -      | -    |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| item | 附件，同 Upload `UploadFile` | Attachment | - | - |
+| onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean \| Promise | - | - |
 
 ## Semantic DOM
 

--- a/docs/component/attachments.md
+++ b/docs/component/attachments.md
@@ -1,4 +1,3 @@
-
 # Attachments 输入附件
 
 用于展示一组附件信息集合。
@@ -69,18 +68,18 @@ attachments/files
 
 继承 antdv [Upload](https://www.antdv.com/components/upload-cn) 属性。
 
-| 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| classNames | 自定义样式类名，[见下](#semantic-dom) | Record<string, string> | - | - |
-| disabled | 是否禁用 | boolean | false | - |
-| getDropContainer | 设置拖拽时，可以释放文件的区域 | () => HTMLElement | - | - |
-| items | 附件列表，同 Upload `fileList` | Attachment[] | - | - |
-| overflow | 文件列表超出时样式 | 'wrap' \| 'scrollX' \| 'scrollY' | - | - |
-| placeholder | 没有文件时的占位信息 | PlaceholderType \| ((type: 'inline' \| 'drop') => PlaceholderType) | - | - |
-| rootClassName | 根节点的样式类名 | string | - | - |
-| rootStyle | 根节点的样式对象 | CSSProperties | - | - |
-| styles | 自定义样式对象，[见下](#semantic-dom) | Record<string, CSSProperties> | - | - |
-| imageProps | 图片属性，同 antdv [Image](https://www.antdv.com/components/image-cn) 属性 | ImageProps | - | - |
+| 属性             | 说明                                                                       | 类型                                                               | 默认值 | 版本 |
+| ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------ | ---- |
+| classNames       | 自定义样式类名，[见下](#semantic-dom)                                      | Record<string, string>                                             | -      | -    |
+| disabled         | 是否禁用                                                                   | boolean                                                            | false  | -    |
+| getDropContainer | 设置拖拽时，可以释放文件的区域                                             | () => HTMLElement                                                  | -      | -    |
+| items            | 附件列表，同 Upload `fileList`                                             | Attachment[]                                                       | -      | -    |
+| overflow         | 文件列表超出时样式                                                         | 'wrap' \| 'scrollX' \| 'scrollY'                                   | -      | -    |
+| placeholder      | 没有文件时的占位信息                                                       | PlaceholderType \| ((type: 'inline' \| 'drop') => PlaceholderType) | -      | -    |
+| rootClassName    | 根节点的样式类名                                                           | string                                                             | -      | -    |
+| rootStyle        | 根节点的样式对象                                                           | CSSProperties                                                      | -      | -    |
+| styles           | 自定义样式对象，[见下](#semantic-dom)                                      | Record<string, CSSProperties>                                      | -      | -    |
+| imageProps       | 图片属性，同 antdv [Image](https://www.antdv.com/components/image-cn) 属性 | ImageProps                                                         | -      | -    |
 
 ```tsx | pure
 interface PlaceholderType {
@@ -92,23 +91,23 @@ interface PlaceholderType {
 
 ### Attachments Slots
 
-| 插槽名 | 说明 | 类型 |
-| --- | --- | --- |
+| 插槽名      | 说明                 | 类型                           |
+| ----------- | -------------------- | ------------------------------ |
 | placeholder | 没有文件时的占位信息 | \{ type: "inline" \| "drop" \} |
 
 ### Attachments Expose
 
-| 属性          | 说明             | 类型                 | 版本 |
-| ------------- | ---------------- | -------------------- | ---- |
-| nativeElement | 获取原生节点     | HTMLElement          | -    |
-| upload        | 手工调用上传文件 | (file: File) => void | -    |
+| 属性          | 说明             | 类型                                       | 版本 |
+| ------------- | ---------------- | ------------------------------------------ | ---- |
+| nativeElement | 获取原生节点     | HTMLElement                                | -    |
+| upload        | 手工调用上传文件 | (file: File \| File[] \| FileList) => void | -    |
 
 ### Attachments.FileCard Props
 
-| 属性 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| item | 附件，同 Upload `UploadFile` | Attachment | - | - |
-| onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean \| Promise | - | - |
+| 属性     | 说明                                                                                                                     | 类型                                     | 默认值 | 版本 |
+| -------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------ | ---- |
+| item     | 附件，同 Upload `UploadFile`                                                                                             | Attachment                               | -      | -    |
+| onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | (item: Attachment) => boolean \| Promise | -      | -    |
 
 ## Semantic DOM
 

--- a/docs/examples-setup/sender/pasteImage.vue
+++ b/docs/examples-setup/sender/pasteImage.vue
@@ -15,7 +15,7 @@ const open = ref(false);
 const items = ref([]);
 const text = ref('');
 
-const attachmentsRef = ref(null);
+const attachmentsRef = ref<InstanceType<typeof Attachments>>(null);
 const senderRef = ref<InstanceType<typeof Sender>>(null);
 
 const placeholder = (type: PlaceholderType) =>
@@ -33,9 +33,7 @@ const getDropContainer = () => senderRef.value?.nativeElement;
 
 const pastFile: PastFile = (_, files) => {
   console.log("past")
-  for (const file of files) {
-    attachmentsRef.value?.upload(file);
-  }
+  attachmentsRef.value?.upload(files);
   open.value = true;
 }
 

--- a/docs/examples/sender/pasteImage.vue
+++ b/docs/examples/sender/pasteImage.vue
@@ -11,7 +11,7 @@ const Demo = () => {
   const items = ref([]);
   const text = ref('');
 
-  const attachmentsRef = ref(null);
+  const attachmentsRef = ref<InstanceType<typeof Attachments>>(null);
   const senderRef = ref<InstanceType<typeof Sender>>(null);
 
   const senderHeader = computed(() => (
@@ -23,7 +23,7 @@ const Demo = () => {
         },
       }}
       open={open.value}
-      onOpenChange={(v) => (open.value = v)}
+      onOpenChange={v => open.value = v}
       forceRender
     >
       <Attachments
@@ -31,17 +31,17 @@ const Demo = () => {
         // Mock not real upload file
         beforeUpload={() => false}
         items={items.value}
-        onChange={({ fileList }) => (items.value = fileList)}
+        onChange={({ fileList }) => items.value = fileList}
         placeholder={(type) =>
           type === 'drop'
             ? {
-                title: 'Drop file here',
-              }
+              title: 'Drop file here',
+            }
             : {
-                icon: <CloudUploadOutlined />,
-                title: 'Upload files',
-                description: 'Click or drag files to this area to upload',
-              }
+              icon: <CloudUploadOutlined />,
+              title: 'Upload files',
+              description: 'Click or drag files to this area to upload',
+            }
         }
         getDropContainer={() => senderRef.value?.nativeElement}
       />
@@ -63,7 +63,7 @@ const Demo = () => {
           />
         }
         value={text.value}
-        onChange={(v) => (text.value = v)}
+        onChange={v => text.value = v}
         onPasteFile={(_, files) => {
           attachmentsRef.value?.upload(files);
           open.value = true;

--- a/docs/examples/sender/pasteImage.vue
+++ b/docs/examples/sender/pasteImage.vue
@@ -23,7 +23,7 @@ const Demo = () => {
         },
       }}
       open={open.value}
-      onOpenChange={v => open.value = v}
+      onOpenChange={(v) => (open.value = v)}
       forceRender
     >
       <Attachments
@@ -31,17 +31,17 @@ const Demo = () => {
         // Mock not real upload file
         beforeUpload={() => false}
         items={items.value}
-        onChange={({ fileList }) => items.value = fileList}
+        onChange={({ fileList }) => (items.value = fileList)}
         placeholder={(type) =>
           type === 'drop'
             ? {
-              title: 'Drop file here',
-            }
+                title: 'Drop file here',
+              }
             : {
-              icon: <CloudUploadOutlined />,
-              title: 'Upload files',
-              description: 'Click or drag files to this area to upload',
-            }
+                icon: <CloudUploadOutlined />,
+                title: 'Upload files',
+                description: 'Click or drag files to this area to upload',
+              }
         }
         getDropContainer={() => senderRef.value?.nativeElement}
       />
@@ -63,16 +63,14 @@ const Demo = () => {
           />
         }
         value={text.value}
-        onChange={v => text.value = v}
+        onChange={(v) => (text.value = v)}
         onPasteFile={(_, files) => {
-          for (const file of files) {
-            attachmentsRef.value?.upload(file);
-          }
+          attachmentsRef.value?.upload(files);
           open.value = true;
         }}
         onSubmit={() => {
-          items.value = []
-          text.value = ''
+          items.value = [];
+          text.value = '';
         }}
       />
     </Flex>
@@ -84,7 +82,6 @@ defineRender(() => {
     <App>
       <Demo />
     </App>
-  )
+  );
 });
-
 </script>

--- a/src/attachments/Attachments.vue
+++ b/src/attachments/Attachments.vue
@@ -139,23 +139,29 @@ const hasFileList = computed(() => fileList.value.length > 0);
 
 defineExpose<AttachmentsRef>({
   nativeElement: containerRef.value,
-  upload: (files) => {
+  upload: (file) => {
     // get native element
     const fileInput =
       placeholderUploaderRef.value?.nativeElement.querySelector?.(
         'input[type="file"]',
       ) as HTMLInputElement;
+
+    if (!fileInput) return;
     const dataTransfer = new DataTransfer();
-    if (fileInput) {
-      // 确保有length属性 防止ts报错
-      if ('length' in files && files.length >= 1) {
-        const _files = Array.from(files);
-        for (const file of _files) {
-          dataTransfer.items.add(file);
+    try {
+      // 如果有length 说明是由file组成的数组或者FileList 一并处理
+      if ('length' in file && file.length >= 1) {
+        for (let i = 0; i < file.length; i++) {
+          dataTransfer.items.add(file[i]);
         }
+      } else {
+        // 单个File
+        dataTransfer.items.add(file as File);
       }
       fileInput.files = dataTransfer.files;
       fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    } catch (err) {
+      console.error('上传失败', err);
     }
   },
 });

--- a/src/attachments/Attachments.vue
+++ b/src/attachments/Attachments.vue
@@ -70,11 +70,9 @@ const cssinjsCls = computed(() => classnames(hashId.value, cssVarCls));
 
 // ============================ Upload ============================
 const [fileList, setFileList] = useState(items);
-console.log(items, 'items');
 watch(
   () => items,
   () => {
-    console.log('watch', items);
     setFileList(items);
   },
 );

--- a/src/attachments/Attachments.vue
+++ b/src/attachments/Attachments.vue
@@ -3,7 +3,12 @@ import classnames from 'classnames';
 import { computed, useTemplateRef, type VNode, watch } from 'vue';
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import { useXProviderContext } from '../x-provider';
-import type { Attachment, AttachmentsProps, AttachmentsRef, PlaceholderProps } from './interface';
+import type {
+  Attachment,
+  AttachmentsProps,
+  AttachmentsRef,
+  PlaceholderProps,
+} from './interface';
 import PlaceholderUploader from './PlaceholderUploader.vue';
 import type { UploadProps } from 'ant-design-vue';
 import DropArea from './DropArea.vue';
@@ -36,7 +41,7 @@ const {
 } = defineProps<AttachmentsProps>();
 
 const slots = defineSlots<{
-  placeholder?(props?: { type: "inline" | "drop" }): VNode | string;
+  placeholder?(props?: { type: 'inline' | 'drop' }): VNode | string;
 }>();
 
 // ============================ PrefixCls ============================
@@ -54,7 +59,9 @@ const contextStyles = computed(() => contextConfig.value.styles);
 const containerRef = useTemplateRef<HTMLDivElement>('attachments-container');
 // const containerRef = ref<HTMLDivElement>(null);
 
-const placeholderUploaderRef = useTemplateRef<InstanceType<typeof PlaceholderUploader>>('placeholder-uploader');
+const placeholderUploaderRef = useTemplateRef<
+  InstanceType<typeof PlaceholderUploader>
+>('placeholder-uploader');
 
 // ============================ Style ============================
 const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
@@ -63,9 +70,14 @@ const cssinjsCls = computed(() => classnames(hashId.value, cssVarCls));
 
 // ============================ Upload ============================
 const [fileList, setFileList] = useState(items);
-watch(() => items, () => {
-  setFileList(items);
-});
+console.log(items, 'items');
+watch(
+  () => items,
+  () => {
+    console.log('watch', items);
+    setFileList(items);
+  },
+);
 
 const triggerChange: AttachmentsProps['onChange'] = (info) => {
   setFileList(info.fileList);
@@ -79,13 +91,17 @@ const mergedUploadProps = computed<UploadProps>(() => ({
 }));
 
 const onItemRemove = (item: Attachment) =>
-  Promise.resolve(typeof onRemove === 'function' ? onRemove(item) : onRemove).then((ret) => {
+  Promise.resolve(
+    typeof onRemove === 'function' ? onRemove(item) : onRemove,
+  ).then((ret) => {
     // Prevent removing file
     if (ret === false) {
       return;
     }
 
-    const newFileList = fileList.value.filter((fileItem) => fileItem.uid !== item.uid);
+    const newFileList = fileList.value.filter(
+      (fileItem) => fileItem.uid !== item.uid,
+    );
     triggerChange({
       file: { ...item, status: 'removed' },
       fileList: newFileList,
@@ -96,19 +112,21 @@ const getPlaceholderNode = (
   type: 'inline' | 'drop',
   props?: Pick<PlaceholderProps, 'style'>,
 ) => {
-  const placeholderContent =
-    slots.placeholder
-      ? slots.placeholder({ type })
-      : typeof placeholder === 'function'
-        ? placeholder(type)
-        : placeholder;
+  const placeholderContent = slots.placeholder
+    ? slots.placeholder({ type })
+    : typeof placeholder === 'function'
+    ? placeholder(type)
+    : placeholder;
 
   return (
     <PlaceholderUploader
       placeholder={placeholderContent}
       upload={mergedUploadProps.value}
       prefixCls={prefixCls}
-      className={classnames(contextClassNames.value.placeholder, classNames.placeholder)}
+      className={classnames(
+        contextClassNames.value.placeholder,
+        classNames.placeholder,
+      )}
       style={{
         ...contextStyles.value.placeholder,
         ...styles.placeholder,
@@ -123,16 +141,22 @@ const hasFileList = computed(() => fileList.value.length > 0);
 
 defineExpose<AttachmentsRef>({
   nativeElement: containerRef.value,
-  upload: (file) => {
+  upload: (files) => {
     // get native element
-    const fileInput = placeholderUploaderRef.value?.nativeElement.querySelector?.('input[type="file"]') as HTMLInputElement;
-
-    // Trigger native change event
+    const fileInput =
+      placeholderUploaderRef.value?.nativeElement.querySelector?.(
+        'input[type="file"]',
+      ) as HTMLInputElement;
+    const dataTransfer = new DataTransfer();
     if (fileInput) {
-      const dataTransfer = new DataTransfer();
-      dataTransfer.items.add(file);
+      // 确保有length属性 防止ts报错
+      if ('length' in files && files.length >= 1) {
+        const _files = Array.from(files);
+        for (const file of _files) {
+          dataTransfer.items.add(file);
+        }
+      }
       fileInput.files = dataTransfer.files;
-
       fileInput.dispatchEvent(new Event('change', { bubbles: true }));
     }
   },
@@ -186,20 +210,29 @@ defineRender(() => {
             onRemove={onItemRemove}
             overflow={overflow}
             upload={mergedUploadProps.value}
-            listClassName={classnames(contextClassNames.value.list, classNames.list)}
+            listClassName={classnames(
+              contextClassNames.value.list,
+              classNames.list,
+            )}
             listStyle={{
               ...contextStyles.value.list,
               ...styles.list,
               ...(!hasFileList.value && { display: 'none' }),
             }}
-            itemClassName={classnames(contextClassNames.value.item, classNames.item)}
+            itemClassName={classnames(
+              contextClassNames.value.item,
+              classNames.item,
+            )}
             itemStyle={{
               ...contextStyles.value.item,
               ...styles.item,
             }}
             imageProps={imageProps}
           />
-          {getPlaceholderNode('inline', hasFileList.value ? { style: { display: 'none' } } : {})}
+          {getPlaceholderNode(
+            'inline',
+            hasFileList.value ? { style: { display: 'none' } } : {},
+          )}
           <DropArea
             getDropContainer={getDropContainer || (() => containerRef.value)}
             prefixCls={prefixCls}
@@ -208,7 +241,7 @@ defineRender(() => {
           />
         </div>
       )}
-    </AttachmentContextProvider>
-  )
+    </AttachmentContextProvider>,
+  );
 });
 </script>

--- a/src/attachments/Attachments.vue
+++ b/src/attachments/Attachments.vue
@@ -3,12 +3,7 @@ import classnames from 'classnames';
 import { computed, useTemplateRef, type VNode, watch } from 'vue';
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import { useXProviderContext } from '../x-provider';
-import type {
-  Attachment,
-  AttachmentsProps,
-  AttachmentsRef,
-  PlaceholderProps,
-} from './interface';
+import type { Attachment, AttachmentsProps, AttachmentsRef, PlaceholderProps } from './interface';
 import PlaceholderUploader from './PlaceholderUploader.vue';
 import type { UploadProps } from 'ant-design-vue';
 import DropArea from './DropArea.vue';
@@ -59,9 +54,7 @@ const contextStyles = computed(() => contextConfig.value.styles);
 const containerRef = useTemplateRef<HTMLDivElement>('attachments-container');
 // const containerRef = ref<HTMLDivElement>(null);
 
-const placeholderUploaderRef = useTemplateRef<
-  InstanceType<typeof PlaceholderUploader>
->('placeholder-uploader');
+const placeholderUploaderRef = useTemplateRef<InstanceType<typeof PlaceholderUploader>>('placeholder-uploader');
 
 // ============================ Style ============================
 const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
@@ -70,12 +63,9 @@ const cssinjsCls = computed(() => classnames(hashId.value, cssVarCls));
 
 // ============================ Upload ============================
 const [fileList, setFileList] = useState(items);
-watch(
-  () => items,
-  () => {
-    setFileList(items);
-  },
-);
+watch(() => items, () => {
+  setFileList(items);
+});
 
 const triggerChange: AttachmentsProps['onChange'] = (info) => {
   setFileList(info.fileList);
@@ -89,17 +79,13 @@ const mergedUploadProps = computed<UploadProps>(() => ({
 }));
 
 const onItemRemove = (item: Attachment) =>
-  Promise.resolve(
-    typeof onRemove === 'function' ? onRemove(item) : onRemove,
-  ).then((ret) => {
+  Promise.resolve(typeof onRemove === 'function' ? onRemove(item) : onRemove).then((ret) => {
     // Prevent removing file
     if (ret === false) {
       return;
     }
 
-    const newFileList = fileList.value.filter(
-      (fileItem) => fileItem.uid !== item.uid,
-    );
+    const newFileList = fileList.value.filter((fileItem) => fileItem.uid !== item.uid);
     triggerChange({
       file: { ...item, status: 'removed' },
       fileList: newFileList,
@@ -113,18 +99,15 @@ const getPlaceholderNode = (
   const placeholderContent = slots.placeholder
     ? slots.placeholder({ type })
     : typeof placeholder === 'function'
-    ? placeholder(type)
-    : placeholder;
+      ? placeholder(type)
+      : placeholder;
 
   return (
     <PlaceholderUploader
       placeholder={placeholderContent}
       upload={mergedUploadProps.value}
       prefixCls={prefixCls}
-      className={classnames(
-        contextClassNames.value.placeholder,
-        classNames.placeholder,
-      )}
+      className={classnames(contextClassNames.value.placeholder, classNames.placeholder)}
       style={{
         ...contextStyles.value.placeholder,
         ...styles.placeholder,
@@ -141,27 +124,25 @@ defineExpose<AttachmentsRef>({
   nativeElement: containerRef.value,
   upload: (file) => {
     // get native element
-    const fileInput =
-      placeholderUploaderRef.value?.nativeElement.querySelector?.(
-        'input[type="file"]',
-      ) as HTMLInputElement;
+    const fileInput = placeholderUploaderRef.value?.nativeElement.querySelector?.('input[type="file"]') as HTMLInputElement;
 
     if (!fileInput) return;
+
     const dataTransfer = new DataTransfer();
     try {
-      // 如果有length 说明是由file组成的数组或者FileList 一并处理
+      // If length exists, it's a File array or FileList — handle together.
       if ('length' in file && file.length >= 1) {
         for (let i = 0; i < file.length; i++) {
           dataTransfer.items.add(file[i]);
         }
       } else {
-        // 单个File
+        // Single File
         dataTransfer.items.add(file as File);
       }
       fileInput.files = dataTransfer.files;
       fileInput.dispatchEvent(new Event('change', { bubbles: true }));
     } catch (err) {
-      console.error('上传失败', err);
+      console.error('upload failed', err);
     }
   },
 });
@@ -214,29 +195,20 @@ defineRender(() => {
             onRemove={onItemRemove}
             overflow={overflow}
             upload={mergedUploadProps.value}
-            listClassName={classnames(
-              contextClassNames.value.list,
-              classNames.list,
-            )}
+            listClassName={classnames(contextClassNames.value.list, classNames.list)}
             listStyle={{
               ...contextStyles.value.list,
               ...styles.list,
               ...(!hasFileList.value && { display: 'none' }),
             }}
-            itemClassName={classnames(
-              contextClassNames.value.item,
-              classNames.item,
-            )}
+            itemClassName={classnames(contextClassNames.value.item, classNames.item)}
             itemStyle={{
               ...contextStyles.value.item,
               ...styles.item,
             }}
             imageProps={imageProps}
           />
-          {getPlaceholderNode(
-            'inline',
-            hasFileList.value ? { style: { display: 'none' } } : {},
-          )}
+          {getPlaceholderNode('inline', hasFileList.value ? { style: { display: 'none' } } : {})}
           <DropArea
             getDropContainer={getDropContainer || (() => containerRef.value)}
             prefixCls={prefixCls}

--- a/src/attachments/interface.ts
+++ b/src/attachments/interface.ts
@@ -1,10 +1,5 @@
-import type {
-  ImageProps,
-  UploadChangeParam,
-  UploadFile,
-  UploadProps,
-} from 'ant-design-vue';
-import type { CSSProperties, VNode } from 'vue';
+import type { ImageProps, UploadChangeParam, UploadFile, UploadProps } from "ant-design-vue";
+import type { CSSProperties, VNode } from "vue";
 
 export interface AttachmentContextProps {
   disabled?: boolean;
@@ -141,9 +136,7 @@ export interface AttachmentsProps extends AntdUploadProps {
   disabled?: boolean;
 
   // ============= placeholder =============
-  placeholder?:
-    | PlaceholderType
-    | ((type: 'inline' | 'drop') => PlaceholderType);
+  placeholder?: PlaceholderType | ((type: 'inline' | 'drop') => PlaceholderType);
   getDropContainer?: null | (() => HTMLElement | null | undefined);
 
   // ============== File List ==============

--- a/src/attachments/interface.ts
+++ b/src/attachments/interface.ts
@@ -156,5 +156,5 @@ export interface AttachmentsProps extends AntdUploadProps {
 
 export interface AttachmentsRef {
   nativeElement: HTMLDivElement | null;
-  upload: (file: FileList) => void;
+  upload: (file: File | File[] | FileList) => void;
 }

--- a/src/attachments/interface.ts
+++ b/src/attachments/interface.ts
@@ -1,5 +1,10 @@
-import type { ImageProps, UploadChangeParam, UploadFile, UploadProps } from "ant-design-vue";
-import type { CSSProperties, VNode } from "vue";
+import type {
+  ImageProps,
+  UploadChangeParam,
+  UploadFile,
+  UploadProps,
+} from 'ant-design-vue';
+import type { CSSProperties, VNode } from 'vue';
 
 export interface AttachmentContextProps {
   disabled?: boolean;
@@ -50,7 +55,6 @@ export interface FileListProps {
   itemClassName?: string;
   itemStyle?: CSSProperties;
 }
-
 
 export interface FileListCardProps {
   prefixCls?: string;
@@ -137,7 +141,9 @@ export interface AttachmentsProps extends AntdUploadProps {
   disabled?: boolean;
 
   // ============= placeholder =============
-  placeholder?: PlaceholderType | ((type: 'inline' | 'drop') => PlaceholderType);
+  placeholder?:
+    | PlaceholderType
+    | ((type: 'inline' | 'drop') => PlaceholderType);
   getDropContainer?: null | (() => HTMLElement | null | undefined);
 
   // ============== File List ==============
@@ -150,5 +156,5 @@ export interface AttachmentsProps extends AntdUploadProps {
 
 export interface AttachmentsRef {
   nativeElement: HTMLDivElement | null;
-  upload: (file: File) => void;
+  upload: (file: FileList) => void;
 }


### PR DESCRIPTION
Close #403 .

### Describe
When you have copied multiple files and pasted them into the input box, you'll find that it has only pasted one file.This PR supports the ability to paste multiple files.

<img width="601" height="212" alt="image" src="https://github.com/user-attachments/assets/482dec39-f0b1-4c17-871a-677e08a18c85" />

### before
<img width="705" height="431" alt="image" src="https://github.com/user-attachments/assets/96a0931f-6b08-4f07-9370-153607129c0a" />

### after
<img width="769" height="485" alt="image" src="https://github.com/user-attachments/assets/d0ff7467-719b-4b7e-8b20-8d4cac5e41b2" />


related #403 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and consistency across components for better readability.
  * Simplified file upload logic to handle multiple files at once in relevant components.
  * Updated method signatures to support multiple file uploads.

* **New Features**
  * The upload functionality now allows uploading multiple files simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->