### PR TITLE
style: 演示demo 最小宽度修改 #411

### DIFF
--- a/docs/examples-setup/playground/copilot.vue
+++ b/docs/examples-setup/playground/copilot.vue
@@ -329,7 +329,7 @@ const styles = computed(() => {
 const workareaStyles = computed(() => {
   return {
     copilotWrapper: {
-      'min-width': '1000px',
+      'min-width': '970px',
       height: '100vh',
       display: 'flex',
     },

--- a/docs/examples-setup/playground/independent.vue
+++ b/docs/examples-setup/playground/independent.vue
@@ -32,7 +32,7 @@ const styles = computed(() => {
   return {
     'layout': {
       'width': '100%',
-      'min-width': '1000px',
+      'min-width': '970px',
       'height': '722px',
       'border-radius': `${token.value.borderRadius}px`,
       'display': 'flex',

--- a/docs/examples/playground/copilot.vue
+++ b/docs/examples/playground/copilot.vue
@@ -531,7 +531,7 @@ const styles = computed(() => {
 const workareaStyles = computed(() => {
   return {
     copilotWrapper: {
-      'min-width': '1000px',
+      'min-width': '970px',
       height: '100vh',
       display: 'flex',
     },

--- a/docs/examples/playground/independent.vue
+++ b/docs/examples/playground/independent.vue
@@ -125,7 +125,7 @@ const styles = computed(() => {
   return {
     layout: {
       width: '100%',
-      'min-width': '1000px',
+      'min-width': '970px',
       height: '722px',
       'border-radius': `${token.value.borderRadius}px`,
       display: 'flex',


### PR DESCRIPTION
修改前：
<img width="2233" height="1159" alt="image" src="https://github.com/user-attachments/assets/5cfee994-d06e-4938-b536-84db9e2d9cf3" />

修改后：
<img width="2178" height="1189" alt="image" src="https://github.com/user-attachments/assets/f26f8833-f84c-4073-84c3-db6e5851dbc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the minimum width of main layout containers and copilot wrappers from 1000px to 970px in various playground examples for a more compact display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->