### PR TITLE
feat(contributors): add contributors section to documentation and scripts for automatic updates

### DIFF
--- a/contributors/contributors.json
+++ b/contributors/contributors.json
@@ -1,0 +1,1373 @@
+{
+  "total": 26,
+  "repository": {
+    "owner": "wzc520pyfm",
+    "repo": "ant-design-x-vue",
+    "url": "https://github.com/wzc520pyfm/ant-design-x-vue"
+  },
+  "lastUpdated": "2025-08-11T15:21:16.228Z",
+  "contributors": [
+    {
+      "login": "wzc520pyfm",
+      "id": 69044080,
+      "node_id": "MDQ6VXNlcjY5MDQ0MDgw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69044080?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wzc520pyfm",
+      "html_url": "https://github.com/wzc520pyfm",
+      "followers_url": "https://api.github.com/users/wzc520pyfm/followers",
+      "following_url": "https://api.github.com/users/wzc520pyfm/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wzc520pyfm/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wzc520pyfm/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wzc520pyfm/subscriptions",
+      "organizations_url": "https://api.github.com/users/wzc520pyfm/orgs",
+      "repos_url": "https://api.github.com/users/wzc520pyfm/repos",
+      "events_url": "https://api.github.com/users/wzc520pyfm/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wzc520pyfm/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 358
+    },
+    {
+      "login": "Bao0630",
+      "id": 52953943,
+      "node_id": "MDQ6VXNlcjUyOTUzOTQz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52953943?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Bao0630",
+      "html_url": "https://github.com/Bao0630",
+      "followers_url": "https://api.github.com/users/Bao0630/followers",
+      "following_url": "https://api.github.com/users/Bao0630/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Bao0630/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Bao0630/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Bao0630/subscriptions",
+      "organizations_url": "https://api.github.com/users/Bao0630/orgs",
+      "repos_url": "https://api.github.com/users/Bao0630/repos",
+      "events_url": "https://api.github.com/users/Bao0630/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Bao0630/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 13
+    },
+    {
+      "login": "linhf123",
+      "id": 32009993,
+      "node_id": "MDQ6VXNlcjMyMDA5OTkz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/32009993?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/linhf123",
+      "html_url": "https://github.com/linhf123",
+      "followers_url": "https://api.github.com/users/linhf123/followers",
+      "following_url": "https://api.github.com/users/linhf123/following{/other_user}",
+      "gists_url": "https://api.github.com/users/linhf123/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/linhf123/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/linhf123/subscriptions",
+      "organizations_url": "https://api.github.com/users/linhf123/orgs",
+      "repos_url": "https://api.github.com/users/linhf123/repos",
+      "events_url": "https://api.github.com/users/linhf123/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/linhf123/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 11
+    },
+    {
+      "login": "renovate[bot]",
+      "id": 29139614,
+      "node_id": "MDM6Qm90MjkxMzk2MTQ=",
+      "avatar_url": "https://avatars.githubusercontent.com/in/2740?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/renovate%5Bbot%5D",
+      "html_url": "https://github.com/apps/renovate",
+      "followers_url": "https://api.github.com/users/renovate%5Bbot%5D/followers",
+      "following_url": "https://api.github.com/users/renovate%5Bbot%5D/following{/other_user}",
+      "gists_url": "https://api.github.com/users/renovate%5Bbot%5D/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/renovate%5Bbot%5D/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/renovate%5Bbot%5D/subscriptions",
+      "organizations_url": "https://api.github.com/users/renovate%5Bbot%5D/orgs",
+      "repos_url": "https://api.github.com/users/renovate%5Bbot%5D/repos",
+      "events_url": "https://api.github.com/users/renovate%5Bbot%5D/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/renovate%5Bbot%5D/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 5
+    },
+    {
+      "login": "yuxi-ovo",
+      "id": 84778445,
+      "node_id": "MDQ6VXNlcjg0Nzc4NDQ1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84778445?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/yuxi-ovo",
+      "html_url": "https://github.com/yuxi-ovo",
+      "followers_url": "https://api.github.com/users/yuxi-ovo/followers",
+      "following_url": "https://api.github.com/users/yuxi-ovo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/yuxi-ovo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/yuxi-ovo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/yuxi-ovo/subscriptions",
+      "organizations_url": "https://api.github.com/users/yuxi-ovo/orgs",
+      "repos_url": "https://api.github.com/users/yuxi-ovo/repos",
+      "events_url": "https://api.github.com/users/yuxi-ovo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/yuxi-ovo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 5
+    },
+    {
+      "login": "StudyDayByDay",
+      "id": 45332012,
+      "node_id": "MDQ6VXNlcjQ1MzMyMDEy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/45332012?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/StudyDayByDay",
+      "html_url": "https://github.com/StudyDayByDay",
+      "followers_url": "https://api.github.com/users/StudyDayByDay/followers",
+      "following_url": "https://api.github.com/users/StudyDayByDay/following{/other_user}",
+      "gists_url": "https://api.github.com/users/StudyDayByDay/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/StudyDayByDay/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/StudyDayByDay/subscriptions",
+      "organizations_url": "https://api.github.com/users/StudyDayByDay/orgs",
+      "repos_url": "https://api.github.com/users/StudyDayByDay/repos",
+      "events_url": "https://api.github.com/users/StudyDayByDay/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/StudyDayByDay/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "hihanley",
+      "id": 43161625,
+      "node_id": "MDQ6VXNlcjQzMTYxNjI1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/43161625?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/hihanley",
+      "html_url": "https://github.com/hihanley",
+      "followers_url": "https://api.github.com/users/hihanley/followers",
+      "following_url": "https://api.github.com/users/hihanley/following{/other_user}",
+      "gists_url": "https://api.github.com/users/hihanley/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/hihanley/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/hihanley/subscriptions",
+      "organizations_url": "https://api.github.com/users/hihanley/orgs",
+      "repos_url": "https://api.github.com/users/hihanley/repos",
+      "events_url": "https://api.github.com/users/hihanley/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/hihanley/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "inCBle",
+      "id": 84701254,
+      "node_id": "MDQ6VXNlcjg0NzAxMjU0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84701254?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/inCBle",
+      "html_url": "https://github.com/inCBle",
+      "followers_url": "https://api.github.com/users/inCBle/followers",
+      "following_url": "https://api.github.com/users/inCBle/following{/other_user}",
+      "gists_url": "https://api.github.com/users/inCBle/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/inCBle/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/inCBle/subscriptions",
+      "organizations_url": "https://api.github.com/users/inCBle/orgs",
+      "repos_url": "https://api.github.com/users/inCBle/repos",
+      "events_url": "https://api.github.com/users/inCBle/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/inCBle/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "vhxubo",
+      "id": 17352372,
+      "node_id": "MDQ6VXNlcjE3MzUyMzcy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17352372?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/vhxubo",
+      "html_url": "https://github.com/vhxubo",
+      "followers_url": "https://api.github.com/users/vhxubo/followers",
+      "following_url": "https://api.github.com/users/vhxubo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/vhxubo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/vhxubo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/vhxubo/subscriptions",
+      "organizations_url": "https://api.github.com/users/vhxubo/orgs",
+      "repos_url": "https://api.github.com/users/vhxubo/repos",
+      "events_url": "https://api.github.com/users/vhxubo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/vhxubo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "PeikyLiu",
+      "id": 46105662,
+      "node_id": "MDQ6VXNlcjQ2MTA1NjYy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46105662?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/PeikyLiu",
+      "html_url": "https://github.com/PeikyLiu",
+      "followers_url": "https://api.github.com/users/PeikyLiu/followers",
+      "following_url": "https://api.github.com/users/PeikyLiu/following{/other_user}",
+      "gists_url": "https://api.github.com/users/PeikyLiu/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/PeikyLiu/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/PeikyLiu/subscriptions",
+      "organizations_url": "https://api.github.com/users/PeikyLiu/orgs",
+      "repos_url": "https://api.github.com/users/PeikyLiu/repos",
+      "events_url": "https://api.github.com/users/PeikyLiu/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/PeikyLiu/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "wangyonghui0394",
+      "id": 58975095,
+      "node_id": "MDQ6VXNlcjU4OTc1MDk1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/58975095?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wangyonghui0394",
+      "html_url": "https://github.com/wangyonghui0394",
+      "followers_url": "https://api.github.com/users/wangyonghui0394/followers",
+      "following_url": "https://api.github.com/users/wangyonghui0394/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wangyonghui0394/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wangyonghui0394/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wangyonghui0394/subscriptions",
+      "organizations_url": "https://api.github.com/users/wangyonghui0394/orgs",
+      "repos_url": "https://api.github.com/users/wangyonghui0394/repos",
+      "events_url": "https://api.github.com/users/wangyonghui0394/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wangyonghui0394/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "w2xi",
+      "id": 57785259,
+      "node_id": "MDQ6VXNlcjU3Nzg1MjU5",
+      "avatar_url": "https://avatars.githubusercontent.com/u/57785259?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/w2xi",
+      "html_url": "https://github.com/w2xi",
+      "followers_url": "https://api.github.com/users/w2xi/followers",
+      "following_url": "https://api.github.com/users/w2xi/following{/other_user}",
+      "gists_url": "https://api.github.com/users/w2xi/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/w2xi/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/w2xi/subscriptions",
+      "organizations_url": "https://api.github.com/users/w2xi/orgs",
+      "repos_url": "https://api.github.com/users/w2xi/repos",
+      "events_url": "https://api.github.com/users/w2xi/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/w2xi/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "clddup",
+      "id": 105873086,
+      "node_id": "U_kgDOBk9-vg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/105873086?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/clddup",
+      "html_url": "https://github.com/clddup",
+      "followers_url": "https://api.github.com/users/clddup/followers",
+      "following_url": "https://api.github.com/users/clddup/following{/other_user}",
+      "gists_url": "https://api.github.com/users/clddup/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/clddup/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/clddup/subscriptions",
+      "organizations_url": "https://api.github.com/users/clddup/orgs",
+      "repos_url": "https://api.github.com/users/clddup/repos",
+      "events_url": "https://api.github.com/users/clddup/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/clddup/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "zoeyzhao19",
+      "id": 70888488,
+      "node_id": "MDQ6VXNlcjcwODg4NDg4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/70888488?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/zoeyzhao19",
+      "html_url": "https://github.com/zoeyzhao19",
+      "followers_url": "https://api.github.com/users/zoeyzhao19/followers",
+      "following_url": "https://api.github.com/users/zoeyzhao19/following{/other_user}",
+      "gists_url": "https://api.github.com/users/zoeyzhao19/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/zoeyzhao19/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/zoeyzhao19/subscriptions",
+      "organizations_url": "https://api.github.com/users/zoeyzhao19/orgs",
+      "repos_url": "https://api.github.com/users/zoeyzhao19/repos",
+      "events_url": "https://api.github.com/users/zoeyzhao19/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/zoeyzhao19/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "ONLY-yours",
+      "id": 52664827,
+      "node_id": "MDQ6VXNlcjUyNjY0ODI3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52664827?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/ONLY-yours",
+      "html_url": "https://github.com/ONLY-yours",
+      "followers_url": "https://api.github.com/users/ONLY-yours/followers",
+      "following_url": "https://api.github.com/users/ONLY-yours/following{/other_user}",
+      "gists_url": "https://api.github.com/users/ONLY-yours/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/ONLY-yours/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/ONLY-yours/subscriptions",
+      "organizations_url": "https://api.github.com/users/ONLY-yours/orgs",
+      "repos_url": "https://api.github.com/users/ONLY-yours/repos",
+      "events_url": "https://api.github.com/users/ONLY-yours/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/ONLY-yours/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "kieranwv",
+      "id": 47177021,
+      "node_id": "MDQ6VXNlcjQ3MTc3MDIx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/47177021?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/kieranwv",
+      "html_url": "https://github.com/kieranwv",
+      "followers_url": "https://api.github.com/users/kieranwv/followers",
+      "following_url": "https://api.github.com/users/kieranwv/following{/other_user}",
+      "gists_url": "https://api.github.com/users/kieranwv/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/kieranwv/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/kieranwv/subscriptions",
+      "organizations_url": "https://api.github.com/users/kieranwv/orgs",
+      "repos_url": "https://api.github.com/users/kieranwv/repos",
+      "events_url": "https://api.github.com/users/kieranwv/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/kieranwv/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "EralChen",
+      "id": 82485978,
+      "node_id": "MDQ6VXNlcjgyNDg1OTc4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82485978?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/EralChen",
+      "html_url": "https://github.com/EralChen",
+      "followers_url": "https://api.github.com/users/EralChen/followers",
+      "following_url": "https://api.github.com/users/EralChen/following{/other_user}",
+      "gists_url": "https://api.github.com/users/EralChen/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/EralChen/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/EralChen/subscriptions",
+      "organizations_url": "https://api.github.com/users/EralChen/orgs",
+      "repos_url": "https://api.github.com/users/EralChen/repos",
+      "events_url": "https://api.github.com/users/EralChen/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/EralChen/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "chaosll",
+      "id": 100918163,
+      "node_id": "U_kgDOBgPjkw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/100918163?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chaosll",
+      "html_url": "https://github.com/chaosll",
+      "followers_url": "https://api.github.com/users/chaosll/followers",
+      "following_url": "https://api.github.com/users/chaosll/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chaosll/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chaosll/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chaosll/subscriptions",
+      "organizations_url": "https://api.github.com/users/chaosll/orgs",
+      "repos_url": "https://api.github.com/users/chaosll/repos",
+      "events_url": "https://api.github.com/users/chaosll/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chaosll/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "wh-Cc",
+      "id": 30167102,
+      "node_id": "MDQ6VXNlcjMwMTY3MTAy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30167102?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wh-Cc",
+      "html_url": "https://github.com/wh-Cc",
+      "followers_url": "https://api.github.com/users/wh-Cc/followers",
+      "following_url": "https://api.github.com/users/wh-Cc/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wh-Cc/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wh-Cc/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wh-Cc/subscriptions",
+      "organizations_url": "https://api.github.com/users/wh-Cc/orgs",
+      "repos_url": "https://api.github.com/users/wh-Cc/repos",
+      "events_url": "https://api.github.com/users/wh-Cc/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wh-Cc/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "erupts",
+      "id": 20358088,
+      "node_id": "MDQ6VXNlcjIwMzU4MDg4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20358088?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/erupts",
+      "html_url": "https://github.com/erupts",
+      "followers_url": "https://api.github.com/users/erupts/followers",
+      "following_url": "https://api.github.com/users/erupts/following{/other_user}",
+      "gists_url": "https://api.github.com/users/erupts/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/erupts/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/erupts/subscriptions",
+      "organizations_url": "https://api.github.com/users/erupts/orgs",
+      "repos_url": "https://api.github.com/users/erupts/repos",
+      "events_url": "https://api.github.com/users/erupts/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/erupts/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "quanbisen",
+      "id": 28393899,
+      "node_id": "MDQ6VXNlcjI4MzkzODk5",
+      "avatar_url": "https://avatars.githubusercontent.com/u/28393899?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/quanbisen",
+      "html_url": "https://github.com/quanbisen",
+      "followers_url": "https://api.github.com/users/quanbisen/followers",
+      "following_url": "https://api.github.com/users/quanbisen/following{/other_user}",
+      "gists_url": "https://api.github.com/users/quanbisen/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/quanbisen/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/quanbisen/subscriptions",
+      "organizations_url": "https://api.github.com/users/quanbisen/orgs",
+      "repos_url": "https://api.github.com/users/quanbisen/repos",
+      "events_url": "https://api.github.com/users/quanbisen/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/quanbisen/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "wujunyi0907",
+      "id": 170733327,
+      "node_id": "U_kgDOCi0vDw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/170733327?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wujunyi0907",
+      "html_url": "https://github.com/wujunyi0907",
+      "followers_url": "https://api.github.com/users/wujunyi0907/followers",
+      "following_url": "https://api.github.com/users/wujunyi0907/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wujunyi0907/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wujunyi0907/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wujunyi0907/subscriptions",
+      "organizations_url": "https://api.github.com/users/wujunyi0907/orgs",
+      "repos_url": "https://api.github.com/users/wujunyi0907/repos",
+      "events_url": "https://api.github.com/users/wujunyi0907/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wujunyi0907/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "JACK-ZHANG-coming",
+      "id": 44993003,
+      "node_id": "MDQ6VXNlcjQ0OTkzMDAz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44993003?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/JACK-ZHANG-coming",
+      "html_url": "https://github.com/JACK-ZHANG-coming",
+      "followers_url": "https://api.github.com/users/JACK-ZHANG-coming/followers",
+      "following_url": "https://api.github.com/users/JACK-ZHANG-coming/following{/other_user}",
+      "gists_url": "https://api.github.com/users/JACK-ZHANG-coming/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/JACK-ZHANG-coming/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/JACK-ZHANG-coming/subscriptions",
+      "organizations_url": "https://api.github.com/users/JACK-ZHANG-coming/orgs",
+      "repos_url": "https://api.github.com/users/JACK-ZHANG-coming/repos",
+      "events_url": "https://api.github.com/users/JACK-ZHANG-coming/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/JACK-ZHANG-coming/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "Jarvis2018",
+      "id": 36788851,
+      "node_id": "MDQ6VXNlcjM2Nzg4ODUx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/36788851?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Jarvis2018",
+      "html_url": "https://github.com/Jarvis2018",
+      "followers_url": "https://api.github.com/users/Jarvis2018/followers",
+      "following_url": "https://api.github.com/users/Jarvis2018/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Jarvis2018/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Jarvis2018/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Jarvis2018/subscriptions",
+      "organizations_url": "https://api.github.com/users/Jarvis2018/orgs",
+      "repos_url": "https://api.github.com/users/Jarvis2018/repos",
+      "events_url": "https://api.github.com/users/Jarvis2018/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Jarvis2018/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "enootttt",
+      "id": 103349961,
+      "node_id": "U_kgDOBij-yQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/103349961?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/enootttt",
+      "html_url": "https://github.com/enootttt",
+      "followers_url": "https://api.github.com/users/enootttt/followers",
+      "following_url": "https://api.github.com/users/enootttt/following{/other_user}",
+      "gists_url": "https://api.github.com/users/enootttt/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/enootttt/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/enootttt/subscriptions",
+      "organizations_url": "https://api.github.com/users/enootttt/orgs",
+      "repos_url": "https://api.github.com/users/enootttt/repos",
+      "events_url": "https://api.github.com/users/enootttt/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/enootttt/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "yuguaa",
+      "id": 58333667,
+      "node_id": "MDQ6VXNlcjU4MzMzNjY3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/58333667?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/yuguaa",
+      "html_url": "https://github.com/yuguaa",
+      "followers_url": "https://api.github.com/users/yuguaa/followers",
+      "following_url": "https://api.github.com/users/yuguaa/following{/other_user}",
+      "gists_url": "https://api.github.com/users/yuguaa/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/yuguaa/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/yuguaa/subscriptions",
+      "organizations_url": "https://api.github.com/users/yuguaa/orgs",
+      "repos_url": "https://api.github.com/users/yuguaa/repos",
+      "events_url": "https://api.github.com/users/yuguaa/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/yuguaa/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    }
+  ],
+  "componentContributors": [
+    {
+      "component": "bubble",
+      "path": "src/bubble",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 57,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "李慧峰",
+          "id": 152101725,
+          "avatar_url": "https://github.com/李慧峰.png",
+          "html_url": "https://github.com/李慧峰",
+          "contributions": 1,
+          "type": "User",
+          "email": "103349961+enootttt@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 59
+    },
+    {
+      "component": "sender",
+      "path": "src/sender",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 35,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 11,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 2,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 52
+    },
+    {
+      "component": "welcome",
+      "path": "src/welcome",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "wujunyi0907",
+          "id": 657132794,
+          "avatar_url": "https://github.com/wujunyi0907.png",
+          "html_url": "https://github.com/wujunyi0907",
+          "contributions": 1,
+          "type": "User",
+          "email": "wujunyi0907@163.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "attachments",
+      "path": "src/attachments",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 25
+    },
+    {
+      "component": "conversations",
+      "path": "src/conversations",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "YuePeng",
+          "id": 1210345585,
+          "avatar_url": "https://github.com/YuePeng.png",
+          "html_url": "https://github.com/YuePeng",
+          "contributions": 1,
+          "type": "User",
+          "email": "erupts@126.com"
+        }
+      ],
+      "totalContributions": 14
+    },
+    {
+      "component": "prompts",
+      "path": "src/prompts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 6
+    },
+    {
+      "component": "suggestion",
+      "path": "src/suggestion",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "雨溪",
+          "id": 479162055,
+          "avatar_url": "https://github.com/雨溪.png",
+          "html_url": "https://github.com/雨溪",
+          "contributions": 1,
+          "type": "User",
+          "email": "84778445+yuxi-ovo@users.noreply.github.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "thought-chain",
+      "path": "src/thought-chain",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 1,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 11
+    },
+    {
+      "component": "x-provider",
+      "path": "src/x-provider",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 18,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 1,
+          "type": "User",
+          "email": "linhf123"
+        }
+      ],
+      "totalContributions": 19
+    },
+    {
+      "component": "x-request",
+      "path": "src/x-request",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "x-stream",
+      "path": "src/x-stream",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 1
+    },
+    {
+      "component": "use-x-agent",
+      "path": "src/use-x-agent",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 9
+    },
+    {
+      "component": "use-x-chat",
+      "path": "src/use-x-chat",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    }
+  ],
+  "fileContributors": [
+    {
+      "file": "src/bubble/Bubble.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 57,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "李慧峰",
+          "id": 152101725,
+          "avatar_url": "https://github.com/李慧峰.png",
+          "html_url": "https://github.com/李慧峰",
+          "contributions": 1,
+          "type": "User",
+          "email": "103349961+enootttt@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/sender/Sender.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 35,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 11,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 2,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/welcome/Welcome.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "wujunyi0907",
+          "id": 657132794,
+          "avatar_url": "https://github.com/wujunyi0907.png",
+          "html_url": "https://github.com/wujunyi0907",
+          "contributions": 1,
+          "type": "User",
+          "email": "wujunyi0907@163.com"
+        }
+      ]
+    },
+    {
+      "file": "src/attachments/Attachments.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/conversations/Conversations.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "YuePeng",
+          "id": 1210345585,
+          "avatar_url": "https://github.com/YuePeng.png",
+          "html_url": "https://github.com/YuePeng",
+          "contributions": 1,
+          "type": "User",
+          "email": "erupts@126.com"
+        }
+      ]
+    },
+    {
+      "file": "src/prompts/Prompts.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/suggestion/Suggestion.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "雨溪",
+          "id": 479162055,
+          "avatar_url": "https://github.com/雨溪.png",
+          "html_url": "https://github.com/雨溪",
+          "contributions": 1,
+          "type": "User",
+          "email": "84778445+yuxi-ovo@users.noreply.github.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/thought-chain/ThoughtChain.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 1,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/x-provider/index.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 18,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 1,
+          "type": "User",
+          "email": "linhf123"
+        }
+      ]
+    },
+    {
+      "file": "src/x-request/x-request.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/x-stream/x-stream.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/use-x-agent/use-x-agent.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/use-x-chat/use-x-chat.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    }
+  ]
+}

--- a/contributors/contributors.json
+++ b/contributors/contributors.json
@@ -5,7 +5,7 @@
     "repo": "ant-design-x-vue",
     "url": "https://github.com/wzc520pyfm/ant-design-x-vue"
   },
-  "lastUpdated": "2025-08-11T15:21:16.228Z",
+  "lastUpdated": "2025-08-12T13:24:35.741Z",
   "contributors": [
     {
       "login": "wzc520pyfm",
@@ -27,7 +27,7 @@
       "type": "User",
       "user_view_type": "public",
       "site_admin": false,
-      "contributions": 358
+      "contributions": 360
     },
     {
       "login": "Bao0630",
@@ -986,6 +986,1247 @@
         }
       ],
       "totalContributions": 3
+    },
+    {
+      "component": "bubble-docs",
+      "path": "docs/component/bubble.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 22,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 24
+    },
+    {
+      "component": "sender-docs",
+      "path": "docs/component/sender.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 2,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 18
+    },
+    {
+      "component": "welcome-docs",
+      "path": "docs/component/welcome.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "attachments-docs",
+      "path": "docs/component/attachments.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 16
+    },
+    {
+      "component": "conversations-docs",
+      "path": "docs/component/conversations.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 10
+    },
+    {
+      "component": "prompts-docs",
+      "path": "docs/component/prompts.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 13
+    },
+    {
+      "component": "suggestion-docs",
+      "path": "docs/component/suggestion.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 6
+    },
+    {
+      "component": "thought-chain-docs",
+      "path": "docs/component/thought-chain.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 10
+    },
+    {
+      "component": "x-provider-docs",
+      "path": "docs/component/x-provider.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "x-request-docs",
+      "path": "docs/component/x-request.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "x-stream-docs",
+      "path": "docs/component/x-stream.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "use-x-agent-docs",
+      "path": "docs/component/use-x-agent.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "use-x-chat-docs",
+      "path": "docs/component/use-x-chat.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "bubble-examples",
+      "path": "docs/examples/bubble",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 11,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 12
+    },
+    {
+      "component": "sender-examples",
+      "path": "docs/examples/sender",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 12,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        }
+      ],
+      "totalContributions": 35
+    },
+    {
+      "component": "welcome-examples",
+      "path": "docs/examples/welcome",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "attachments-examples",
+      "path": "docs/examples/attachments",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "conversations-examples",
+      "path": "docs/examples/conversations",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 13
+    },
+    {
+      "component": "prompts-examples",
+      "path": "docs/examples/prompts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 6
+    },
+    {
+      "component": "suggestion-examples",
+      "path": "docs/examples/suggestion",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 4
+    },
+    {
+      "component": "thought-chain-examples",
+      "path": "docs/examples/thought-chain",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 10
+    },
+    {
+      "component": "x-provider-examples",
+      "path": "docs/examples/x-provider",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "x-request-examples",
+      "path": "docs/examples/x-request",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "x-stream-examples",
+      "path": "docs/examples/x-stream",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "use-x-agent-examples",
+      "path": "docs/examples/use-x-agent",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 9
+    },
+    {
+      "component": "use-x-chat-examples",
+      "path": "docs/examples/use-x-chat",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 12
+    },
+    {
+      "component": "playground-examples",
+      "path": "docs/examples/playground",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "bubble-examples-setup",
+      "path": "docs/examples-setup/bubble",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "LIKUN",
+          "id": 1993555782,
+          "avatar_url": "https://github.com/LIKUN.png",
+          "html_url": "https://github.com/LIKUN",
+          "contributions": 3,
+          "type": "User",
+          "email": "45332012+StudyDayByDay@users.noreply.github.com"
+        },
+        {
+          "login": "superlollipop",
+          "id": 404479352,
+          "avatar_url": "https://github.com/superlollipop.png",
+          "html_url": "https://github.com/superlollipop",
+          "contributions": 1,
+          "type": "User",
+          "email": "1769128867@qq.com"
+        }
+      ],
+      "totalContributions": 12
+    },
+    {
+      "component": "sender-examples-setup",
+      "path": "docs/examples-setup/sender",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "专注的小眼神",
+          "id": 367769364,
+          "avatar_url": "https://github.com/专注的小眼神.png",
+          "html_url": "https://github.com/专注的小眼神",
+          "contributions": 1,
+          "type": "User",
+          "email": "36788851+Jarvis2018@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 13
+    },
+    {
+      "component": "welcome-examples-setup",
+      "path": "docs/examples-setup/welcome",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "attachments-examples-setup",
+      "path": "docs/examples-setup/attachments",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "conversations-examples-setup",
+      "path": "docs/examples-setup/conversations",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "prompts-examples-setup",
+      "path": "docs/examples-setup/prompts",
+      "contributors": [
+        {
+          "login": "K.Os",
+          "id": 1728422765,
+          "avatar_url": "https://github.com/K.Os.png",
+          "html_url": "https://github.com/K.Os",
+          "contributions": 1,
+          "type": "User",
+          "email": "100918163+chaosll@users.noreply.github.com"
+        },
+        {
+          "login": "zhangqiang",
+          "id": 1610780964,
+          "avatar_url": "https://github.com/zhangqiang.png",
+          "html_url": "https://github.com/zhangqiang",
+          "contributions": 1,
+          "type": "User",
+          "email": "44993003+JACK-ZHANG-coming@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "suggestion-examples-setup",
+      "path": "docs/examples-setup/suggestion",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "thought-chain-examples-setup",
+      "path": "docs/examples-setup/thought-chain",
+      "contributors": [
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 3,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "x-provider-examples-setup",
+      "path": "docs/examples-setup/x-provider",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "x-request-examples-setup",
+      "path": "docs/examples-setup/x-request",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 4,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "x-stream-examples-setup",
+      "path": "docs/examples-setup/x-stream",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "use-x-agent-examples-setup",
+      "path": "docs/examples-setup/use-x-agent",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "use-x-chat-examples-setup",
+      "path": "docs/examples-setup/use-x-chat",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 4
+    },
+    {
+      "component": "playground-examples-setup",
+      "path": "docs/examples-setup/playground",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 6
     }
   ],
   "fileContributors": [
@@ -1366,6 +2607,1165 @@
           "contributions": 3,
           "type": "User",
           "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/bubble.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 22,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/sender.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 2,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/welcome.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/attachments.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/conversations.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/prompts.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/suggestion.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/thought-chain.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/x-provider.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/x-request.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/x-stream.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/use-x-agent.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/use-x-chat.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/bubble/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 11,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/sender/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 12,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/welcome/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/attachments/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/conversations/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/prompts/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/suggestion/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/thought-chain/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/x-provider/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/x-request/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/x-stream/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/use-x-agent/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/use-x-chat/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/playground/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/bubble/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "LIKUN",
+          "id": 1993555782,
+          "avatar_url": "https://github.com/LIKUN.png",
+          "html_url": "https://github.com/LIKUN",
+          "contributions": 3,
+          "type": "User",
+          "email": "45332012+StudyDayByDay@users.noreply.github.com"
+        },
+        {
+          "login": "superlollipop",
+          "id": 404479352,
+          "avatar_url": "https://github.com/superlollipop.png",
+          "html_url": "https://github.com/superlollipop",
+          "contributions": 1,
+          "type": "User",
+          "email": "1769128867@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/sender/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "专注的小眼神",
+          "id": 367769364,
+          "avatar_url": "https://github.com/专注的小眼神.png",
+          "html_url": "https://github.com/专注的小眼神",
+          "contributions": 1,
+          "type": "User",
+          "email": "36788851+Jarvis2018@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/welcome/basic.vue",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/attachments/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/conversations/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/prompts/basic.vue",
+      "contributors": [
+        {
+          "login": "K.Os",
+          "id": 1728422765,
+          "avatar_url": "https://github.com/K.Os.png",
+          "html_url": "https://github.com/K.Os",
+          "contributions": 1,
+          "type": "User",
+          "email": "100918163+chaosll@users.noreply.github.com"
+        },
+        {
+          "login": "zhangqiang",
+          "id": 1610780964,
+          "avatar_url": "https://github.com/zhangqiang.png",
+          "html_url": "https://github.com/zhangqiang",
+          "contributions": 1,
+          "type": "User",
+          "email": "44993003+JACK-ZHANG-coming@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/suggestion/basic.vue",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/thought-chain/basic.vue",
+      "contributors": [
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 3,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/x-provider/basic.vue",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/x-request/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 4,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/x-stream/basic.vue",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/use-x-agent/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/use-x-chat/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/playground/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
         }
       ]
     }

--- a/contributors/data.ts
+++ b/contributors/data.ts
@@ -1,0 +1,1424 @@
+// This file is auto-generated. Do not edit manually.
+// Last updated: 2025-08-11T15:21:16.228Z
+
+export interface Contributor {
+  login: string
+  id: number
+  node_id?: string
+  avatar_url: string
+  gravatar_id?: string
+  url?: string
+  html_url: string
+  followers_url?: string
+  following_url?: string
+  gists_url?: string
+  starred_url?: string
+  subscriptions_url?: string
+  organizations_url?: string
+  repos_url?: string
+  events_url?: string
+  received_events_url?: string
+  type: string
+  site_admin?: boolean
+  contributions: number
+  email?: string
+}
+
+export interface ComponentContributor {
+  component: string
+  path: string
+  contributors: Contributor[]
+  totalContributions: number
+}
+
+export interface FileContributor {
+  file: string
+  contributors: Contributor[]
+}
+
+export interface ContributorsData {
+  total: number
+  repository: {
+    owner: string
+    repo: string
+    url: string
+  }
+  lastUpdated: string
+  contributors: Contributor[]
+  componentContributors: ComponentContributor[]
+  fileContributors: FileContributor[]
+}
+
+export const contributorsData: ContributorsData = {
+  "total": 26,
+  "repository": {
+    "owner": "wzc520pyfm",
+    "repo": "ant-design-x-vue",
+    "url": "https://github.com/wzc520pyfm/ant-design-x-vue"
+  },
+  "lastUpdated": "2025-08-11T15:21:16.228Z",
+  "contributors": [
+    {
+      "login": "wzc520pyfm",
+      "id": 69044080,
+      "node_id": "MDQ6VXNlcjY5MDQ0MDgw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69044080?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wzc520pyfm",
+      "html_url": "https://github.com/wzc520pyfm",
+      "followers_url": "https://api.github.com/users/wzc520pyfm/followers",
+      "following_url": "https://api.github.com/users/wzc520pyfm/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wzc520pyfm/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wzc520pyfm/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wzc520pyfm/subscriptions",
+      "organizations_url": "https://api.github.com/users/wzc520pyfm/orgs",
+      "repos_url": "https://api.github.com/users/wzc520pyfm/repos",
+      "events_url": "https://api.github.com/users/wzc520pyfm/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wzc520pyfm/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 358
+    },
+    {
+      "login": "Bao0630",
+      "id": 52953943,
+      "node_id": "MDQ6VXNlcjUyOTUzOTQz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52953943?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Bao0630",
+      "html_url": "https://github.com/Bao0630",
+      "followers_url": "https://api.github.com/users/Bao0630/followers",
+      "following_url": "https://api.github.com/users/Bao0630/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Bao0630/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Bao0630/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Bao0630/subscriptions",
+      "organizations_url": "https://api.github.com/users/Bao0630/orgs",
+      "repos_url": "https://api.github.com/users/Bao0630/repos",
+      "events_url": "https://api.github.com/users/Bao0630/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Bao0630/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 13
+    },
+    {
+      "login": "linhf123",
+      "id": 32009993,
+      "node_id": "MDQ6VXNlcjMyMDA5OTkz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/32009993?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/linhf123",
+      "html_url": "https://github.com/linhf123",
+      "followers_url": "https://api.github.com/users/linhf123/followers",
+      "following_url": "https://api.github.com/users/linhf123/following{/other_user}",
+      "gists_url": "https://api.github.com/users/linhf123/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/linhf123/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/linhf123/subscriptions",
+      "organizations_url": "https://api.github.com/users/linhf123/orgs",
+      "repos_url": "https://api.github.com/users/linhf123/repos",
+      "events_url": "https://api.github.com/users/linhf123/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/linhf123/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 11
+    },
+    {
+      "login": "renovate[bot]",
+      "id": 29139614,
+      "node_id": "MDM6Qm90MjkxMzk2MTQ=",
+      "avatar_url": "https://avatars.githubusercontent.com/in/2740?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/renovate%5Bbot%5D",
+      "html_url": "https://github.com/apps/renovate",
+      "followers_url": "https://api.github.com/users/renovate%5Bbot%5D/followers",
+      "following_url": "https://api.github.com/users/renovate%5Bbot%5D/following{/other_user}",
+      "gists_url": "https://api.github.com/users/renovate%5Bbot%5D/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/renovate%5Bbot%5D/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/renovate%5Bbot%5D/subscriptions",
+      "organizations_url": "https://api.github.com/users/renovate%5Bbot%5D/orgs",
+      "repos_url": "https://api.github.com/users/renovate%5Bbot%5D/repos",
+      "events_url": "https://api.github.com/users/renovate%5Bbot%5D/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/renovate%5Bbot%5D/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 5
+    },
+    {
+      "login": "yuxi-ovo",
+      "id": 84778445,
+      "node_id": "MDQ6VXNlcjg0Nzc4NDQ1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84778445?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/yuxi-ovo",
+      "html_url": "https://github.com/yuxi-ovo",
+      "followers_url": "https://api.github.com/users/yuxi-ovo/followers",
+      "following_url": "https://api.github.com/users/yuxi-ovo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/yuxi-ovo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/yuxi-ovo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/yuxi-ovo/subscriptions",
+      "organizations_url": "https://api.github.com/users/yuxi-ovo/orgs",
+      "repos_url": "https://api.github.com/users/yuxi-ovo/repos",
+      "events_url": "https://api.github.com/users/yuxi-ovo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/yuxi-ovo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 5
+    },
+    {
+      "login": "StudyDayByDay",
+      "id": 45332012,
+      "node_id": "MDQ6VXNlcjQ1MzMyMDEy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/45332012?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/StudyDayByDay",
+      "html_url": "https://github.com/StudyDayByDay",
+      "followers_url": "https://api.github.com/users/StudyDayByDay/followers",
+      "following_url": "https://api.github.com/users/StudyDayByDay/following{/other_user}",
+      "gists_url": "https://api.github.com/users/StudyDayByDay/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/StudyDayByDay/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/StudyDayByDay/subscriptions",
+      "organizations_url": "https://api.github.com/users/StudyDayByDay/orgs",
+      "repos_url": "https://api.github.com/users/StudyDayByDay/repos",
+      "events_url": "https://api.github.com/users/StudyDayByDay/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/StudyDayByDay/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "hihanley",
+      "id": 43161625,
+      "node_id": "MDQ6VXNlcjQzMTYxNjI1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/43161625?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/hihanley",
+      "html_url": "https://github.com/hihanley",
+      "followers_url": "https://api.github.com/users/hihanley/followers",
+      "following_url": "https://api.github.com/users/hihanley/following{/other_user}",
+      "gists_url": "https://api.github.com/users/hihanley/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/hihanley/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/hihanley/subscriptions",
+      "organizations_url": "https://api.github.com/users/hihanley/orgs",
+      "repos_url": "https://api.github.com/users/hihanley/repos",
+      "events_url": "https://api.github.com/users/hihanley/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/hihanley/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "inCBle",
+      "id": 84701254,
+      "node_id": "MDQ6VXNlcjg0NzAxMjU0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84701254?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/inCBle",
+      "html_url": "https://github.com/inCBle",
+      "followers_url": "https://api.github.com/users/inCBle/followers",
+      "following_url": "https://api.github.com/users/inCBle/following{/other_user}",
+      "gists_url": "https://api.github.com/users/inCBle/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/inCBle/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/inCBle/subscriptions",
+      "organizations_url": "https://api.github.com/users/inCBle/orgs",
+      "repos_url": "https://api.github.com/users/inCBle/repos",
+      "events_url": "https://api.github.com/users/inCBle/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/inCBle/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "vhxubo",
+      "id": 17352372,
+      "node_id": "MDQ6VXNlcjE3MzUyMzcy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17352372?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/vhxubo",
+      "html_url": "https://github.com/vhxubo",
+      "followers_url": "https://api.github.com/users/vhxubo/followers",
+      "following_url": "https://api.github.com/users/vhxubo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/vhxubo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/vhxubo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/vhxubo/subscriptions",
+      "organizations_url": "https://api.github.com/users/vhxubo/orgs",
+      "repos_url": "https://api.github.com/users/vhxubo/repos",
+      "events_url": "https://api.github.com/users/vhxubo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/vhxubo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "PeikyLiu",
+      "id": 46105662,
+      "node_id": "MDQ6VXNlcjQ2MTA1NjYy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46105662?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/PeikyLiu",
+      "html_url": "https://github.com/PeikyLiu",
+      "followers_url": "https://api.github.com/users/PeikyLiu/followers",
+      "following_url": "https://api.github.com/users/PeikyLiu/following{/other_user}",
+      "gists_url": "https://api.github.com/users/PeikyLiu/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/PeikyLiu/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/PeikyLiu/subscriptions",
+      "organizations_url": "https://api.github.com/users/PeikyLiu/orgs",
+      "repos_url": "https://api.github.com/users/PeikyLiu/repos",
+      "events_url": "https://api.github.com/users/PeikyLiu/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/PeikyLiu/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 3
+    },
+    {
+      "login": "wangyonghui0394",
+      "id": 58975095,
+      "node_id": "MDQ6VXNlcjU4OTc1MDk1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/58975095?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wangyonghui0394",
+      "html_url": "https://github.com/wangyonghui0394",
+      "followers_url": "https://api.github.com/users/wangyonghui0394/followers",
+      "following_url": "https://api.github.com/users/wangyonghui0394/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wangyonghui0394/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wangyonghui0394/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wangyonghui0394/subscriptions",
+      "organizations_url": "https://api.github.com/users/wangyonghui0394/orgs",
+      "repos_url": "https://api.github.com/users/wangyonghui0394/repos",
+      "events_url": "https://api.github.com/users/wangyonghui0394/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wangyonghui0394/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "w2xi",
+      "id": 57785259,
+      "node_id": "MDQ6VXNlcjU3Nzg1MjU5",
+      "avatar_url": "https://avatars.githubusercontent.com/u/57785259?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/w2xi",
+      "html_url": "https://github.com/w2xi",
+      "followers_url": "https://api.github.com/users/w2xi/followers",
+      "following_url": "https://api.github.com/users/w2xi/following{/other_user}",
+      "gists_url": "https://api.github.com/users/w2xi/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/w2xi/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/w2xi/subscriptions",
+      "organizations_url": "https://api.github.com/users/w2xi/orgs",
+      "repos_url": "https://api.github.com/users/w2xi/repos",
+      "events_url": "https://api.github.com/users/w2xi/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/w2xi/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "clddup",
+      "id": 105873086,
+      "node_id": "U_kgDOBk9-vg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/105873086?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/clddup",
+      "html_url": "https://github.com/clddup",
+      "followers_url": "https://api.github.com/users/clddup/followers",
+      "following_url": "https://api.github.com/users/clddup/following{/other_user}",
+      "gists_url": "https://api.github.com/users/clddup/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/clddup/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/clddup/subscriptions",
+      "organizations_url": "https://api.github.com/users/clddup/orgs",
+      "repos_url": "https://api.github.com/users/clddup/repos",
+      "events_url": "https://api.github.com/users/clddup/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/clddup/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "zoeyzhao19",
+      "id": 70888488,
+      "node_id": "MDQ6VXNlcjcwODg4NDg4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/70888488?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/zoeyzhao19",
+      "html_url": "https://github.com/zoeyzhao19",
+      "followers_url": "https://api.github.com/users/zoeyzhao19/followers",
+      "following_url": "https://api.github.com/users/zoeyzhao19/following{/other_user}",
+      "gists_url": "https://api.github.com/users/zoeyzhao19/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/zoeyzhao19/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/zoeyzhao19/subscriptions",
+      "organizations_url": "https://api.github.com/users/zoeyzhao19/orgs",
+      "repos_url": "https://api.github.com/users/zoeyzhao19/repos",
+      "events_url": "https://api.github.com/users/zoeyzhao19/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/zoeyzhao19/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "ONLY-yours",
+      "id": 52664827,
+      "node_id": "MDQ6VXNlcjUyNjY0ODI3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52664827?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/ONLY-yours",
+      "html_url": "https://github.com/ONLY-yours",
+      "followers_url": "https://api.github.com/users/ONLY-yours/followers",
+      "following_url": "https://api.github.com/users/ONLY-yours/following{/other_user}",
+      "gists_url": "https://api.github.com/users/ONLY-yours/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/ONLY-yours/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/ONLY-yours/subscriptions",
+      "organizations_url": "https://api.github.com/users/ONLY-yours/orgs",
+      "repos_url": "https://api.github.com/users/ONLY-yours/repos",
+      "events_url": "https://api.github.com/users/ONLY-yours/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/ONLY-yours/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "kieranwv",
+      "id": 47177021,
+      "node_id": "MDQ6VXNlcjQ3MTc3MDIx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/47177021?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/kieranwv",
+      "html_url": "https://github.com/kieranwv",
+      "followers_url": "https://api.github.com/users/kieranwv/followers",
+      "following_url": "https://api.github.com/users/kieranwv/following{/other_user}",
+      "gists_url": "https://api.github.com/users/kieranwv/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/kieranwv/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/kieranwv/subscriptions",
+      "organizations_url": "https://api.github.com/users/kieranwv/orgs",
+      "repos_url": "https://api.github.com/users/kieranwv/repos",
+      "events_url": "https://api.github.com/users/kieranwv/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/kieranwv/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "EralChen",
+      "id": 82485978,
+      "node_id": "MDQ6VXNlcjgyNDg1OTc4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82485978?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/EralChen",
+      "html_url": "https://github.com/EralChen",
+      "followers_url": "https://api.github.com/users/EralChen/followers",
+      "following_url": "https://api.github.com/users/EralChen/following{/other_user}",
+      "gists_url": "https://api.github.com/users/EralChen/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/EralChen/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/EralChen/subscriptions",
+      "organizations_url": "https://api.github.com/users/EralChen/orgs",
+      "repos_url": "https://api.github.com/users/EralChen/repos",
+      "events_url": "https://api.github.com/users/EralChen/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/EralChen/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 2
+    },
+    {
+      "login": "chaosll",
+      "id": 100918163,
+      "node_id": "U_kgDOBgPjkw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/100918163?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chaosll",
+      "html_url": "https://github.com/chaosll",
+      "followers_url": "https://api.github.com/users/chaosll/followers",
+      "following_url": "https://api.github.com/users/chaosll/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chaosll/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chaosll/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chaosll/subscriptions",
+      "organizations_url": "https://api.github.com/users/chaosll/orgs",
+      "repos_url": "https://api.github.com/users/chaosll/repos",
+      "events_url": "https://api.github.com/users/chaosll/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chaosll/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "wh-Cc",
+      "id": 30167102,
+      "node_id": "MDQ6VXNlcjMwMTY3MTAy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30167102?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wh-Cc",
+      "html_url": "https://github.com/wh-Cc",
+      "followers_url": "https://api.github.com/users/wh-Cc/followers",
+      "following_url": "https://api.github.com/users/wh-Cc/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wh-Cc/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wh-Cc/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wh-Cc/subscriptions",
+      "organizations_url": "https://api.github.com/users/wh-Cc/orgs",
+      "repos_url": "https://api.github.com/users/wh-Cc/repos",
+      "events_url": "https://api.github.com/users/wh-Cc/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wh-Cc/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "erupts",
+      "id": 20358088,
+      "node_id": "MDQ6VXNlcjIwMzU4MDg4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20358088?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/erupts",
+      "html_url": "https://github.com/erupts",
+      "followers_url": "https://api.github.com/users/erupts/followers",
+      "following_url": "https://api.github.com/users/erupts/following{/other_user}",
+      "gists_url": "https://api.github.com/users/erupts/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/erupts/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/erupts/subscriptions",
+      "organizations_url": "https://api.github.com/users/erupts/orgs",
+      "repos_url": "https://api.github.com/users/erupts/repos",
+      "events_url": "https://api.github.com/users/erupts/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/erupts/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "quanbisen",
+      "id": 28393899,
+      "node_id": "MDQ6VXNlcjI4MzkzODk5",
+      "avatar_url": "https://avatars.githubusercontent.com/u/28393899?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/quanbisen",
+      "html_url": "https://github.com/quanbisen",
+      "followers_url": "https://api.github.com/users/quanbisen/followers",
+      "following_url": "https://api.github.com/users/quanbisen/following{/other_user}",
+      "gists_url": "https://api.github.com/users/quanbisen/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/quanbisen/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/quanbisen/subscriptions",
+      "organizations_url": "https://api.github.com/users/quanbisen/orgs",
+      "repos_url": "https://api.github.com/users/quanbisen/repos",
+      "events_url": "https://api.github.com/users/quanbisen/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/quanbisen/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "wujunyi0907",
+      "id": 170733327,
+      "node_id": "U_kgDOCi0vDw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/170733327?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wujunyi0907",
+      "html_url": "https://github.com/wujunyi0907",
+      "followers_url": "https://api.github.com/users/wujunyi0907/followers",
+      "following_url": "https://api.github.com/users/wujunyi0907/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wujunyi0907/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wujunyi0907/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wujunyi0907/subscriptions",
+      "organizations_url": "https://api.github.com/users/wujunyi0907/orgs",
+      "repos_url": "https://api.github.com/users/wujunyi0907/repos",
+      "events_url": "https://api.github.com/users/wujunyi0907/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wujunyi0907/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "JACK-ZHANG-coming",
+      "id": 44993003,
+      "node_id": "MDQ6VXNlcjQ0OTkzMDAz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44993003?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/JACK-ZHANG-coming",
+      "html_url": "https://github.com/JACK-ZHANG-coming",
+      "followers_url": "https://api.github.com/users/JACK-ZHANG-coming/followers",
+      "following_url": "https://api.github.com/users/JACK-ZHANG-coming/following{/other_user}",
+      "gists_url": "https://api.github.com/users/JACK-ZHANG-coming/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/JACK-ZHANG-coming/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/JACK-ZHANG-coming/subscriptions",
+      "organizations_url": "https://api.github.com/users/JACK-ZHANG-coming/orgs",
+      "repos_url": "https://api.github.com/users/JACK-ZHANG-coming/repos",
+      "events_url": "https://api.github.com/users/JACK-ZHANG-coming/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/JACK-ZHANG-coming/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "Jarvis2018",
+      "id": 36788851,
+      "node_id": "MDQ6VXNlcjM2Nzg4ODUx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/36788851?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Jarvis2018",
+      "html_url": "https://github.com/Jarvis2018",
+      "followers_url": "https://api.github.com/users/Jarvis2018/followers",
+      "following_url": "https://api.github.com/users/Jarvis2018/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Jarvis2018/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Jarvis2018/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Jarvis2018/subscriptions",
+      "organizations_url": "https://api.github.com/users/Jarvis2018/orgs",
+      "repos_url": "https://api.github.com/users/Jarvis2018/repos",
+      "events_url": "https://api.github.com/users/Jarvis2018/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Jarvis2018/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "enootttt",
+      "id": 103349961,
+      "node_id": "U_kgDOBij-yQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/103349961?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/enootttt",
+      "html_url": "https://github.com/enootttt",
+      "followers_url": "https://api.github.com/users/enootttt/followers",
+      "following_url": "https://api.github.com/users/enootttt/following{/other_user}",
+      "gists_url": "https://api.github.com/users/enootttt/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/enootttt/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/enootttt/subscriptions",
+      "organizations_url": "https://api.github.com/users/enootttt/orgs",
+      "repos_url": "https://api.github.com/users/enootttt/repos",
+      "events_url": "https://api.github.com/users/enootttt/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/enootttt/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    },
+    {
+      "login": "yuguaa",
+      "id": 58333667,
+      "node_id": "MDQ6VXNlcjU4MzMzNjY3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/58333667?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/yuguaa",
+      "html_url": "https://github.com/yuguaa",
+      "followers_url": "https://api.github.com/users/yuguaa/followers",
+      "following_url": "https://api.github.com/users/yuguaa/following{/other_user}",
+      "gists_url": "https://api.github.com/users/yuguaa/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/yuguaa/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/yuguaa/subscriptions",
+      "organizations_url": "https://api.github.com/users/yuguaa/orgs",
+      "repos_url": "https://api.github.com/users/yuguaa/repos",
+      "events_url": "https://api.github.com/users/yuguaa/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/yuguaa/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false,
+      "contributions": 1
+    }
+  ],
+  "componentContributors": [
+    {
+      "component": "bubble",
+      "path": "src/bubble",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 57,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "李慧峰",
+          "id": 152101725,
+          "avatar_url": "https://github.com/李慧峰.png",
+          "html_url": "https://github.com/李慧峰",
+          "contributions": 1,
+          "type": "User",
+          "email": "103349961+enootttt@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 59
+    },
+    {
+      "component": "sender",
+      "path": "src/sender",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 35,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 11,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 2,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 52
+    },
+    {
+      "component": "welcome",
+      "path": "src/welcome",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "wujunyi0907",
+          "id": 657132794,
+          "avatar_url": "https://github.com/wujunyi0907.png",
+          "html_url": "https://github.com/wujunyi0907",
+          "contributions": 1,
+          "type": "User",
+          "email": "wujunyi0907@163.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "attachments",
+      "path": "src/attachments",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 25
+    },
+    {
+      "component": "conversations",
+      "path": "src/conversations",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "YuePeng",
+          "id": 1210345585,
+          "avatar_url": "https://github.com/YuePeng.png",
+          "html_url": "https://github.com/YuePeng",
+          "contributions": 1,
+          "type": "User",
+          "email": "erupts@126.com"
+        }
+      ],
+      "totalContributions": 14
+    },
+    {
+      "component": "prompts",
+      "path": "src/prompts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 6
+    },
+    {
+      "component": "suggestion",
+      "path": "src/suggestion",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "雨溪",
+          "id": 479162055,
+          "avatar_url": "https://github.com/雨溪.png",
+          "html_url": "https://github.com/雨溪",
+          "contributions": 1,
+          "type": "User",
+          "email": "84778445+yuxi-ovo@users.noreply.github.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "thought-chain",
+      "path": "src/thought-chain",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 1,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 11
+    },
+    {
+      "component": "x-provider",
+      "path": "src/x-provider",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 18,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 1,
+          "type": "User",
+          "email": "linhf123"
+        }
+      ],
+      "totalContributions": 19
+    },
+    {
+      "component": "x-request",
+      "path": "src/x-request",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "x-stream",
+      "path": "src/x-stream",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 1
+    },
+    {
+      "component": "use-x-agent",
+      "path": "src/use-x-agent",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 9
+    },
+    {
+      "component": "use-x-chat",
+      "path": "src/use-x-chat",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    }
+  ],
+  "fileContributors": [
+    {
+      "file": "src/bubble/Bubble.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 57,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "李慧峰",
+          "id": 152101725,
+          "avatar_url": "https://github.com/李慧峰.png",
+          "html_url": "https://github.com/李慧峰",
+          "contributions": 1,
+          "type": "User",
+          "email": "103349961+enootttt@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/sender/Sender.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 35,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 11,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 2,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/welcome/Welcome.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "wujunyi0907",
+          "id": 657132794,
+          "avatar_url": "https://github.com/wujunyi0907.png",
+          "html_url": "https://github.com/wujunyi0907",
+          "contributions": 1,
+          "type": "User",
+          "email": "wujunyi0907@163.com"
+        }
+      ]
+    },
+    {
+      "file": "src/attachments/Attachments.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/conversations/Conversations.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "YuePeng",
+          "id": 1210345585,
+          "avatar_url": "https://github.com/YuePeng.png",
+          "html_url": "https://github.com/YuePeng",
+          "contributions": 1,
+          "type": "User",
+          "email": "erupts@126.com"
+        }
+      ]
+    },
+    {
+      "file": "src/prompts/Prompts.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/suggestion/Suggestion.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "雨溪",
+          "id": 479162055,
+          "avatar_url": "https://github.com/雨溪.png",
+          "html_url": "https://github.com/雨溪",
+          "contributions": 1,
+          "type": "User",
+          "email": "84778445+yuxi-ovo@users.noreply.github.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/thought-chain/ThoughtChain.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "EralChen",
+          "id": 1692035469,
+          "avatar_url": "https://github.com/EralChen.png",
+          "html_url": "https://github.com/EralChen",
+          "contributions": 1,
+          "type": "User",
+          "email": "82485978+EralChen@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "src/x-provider/index.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 18,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 1,
+          "type": "User",
+          "email": "linhf123"
+        }
+      ]
+    },
+    {
+      "file": "src/x-request/x-request.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/x-stream/x-stream.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/use-x-agent/use-x-agent.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "src/use-x-chat/use-x-chat.ts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    }
+  ]
+}

--- a/contributors/data.ts
+++ b/contributors/data.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Last updated: 2025-08-11T15:21:16.228Z
+// Last updated: 2025-08-12T13:24:35.741Z
 
 export interface Contributor {
   login: string
@@ -56,7 +56,7 @@ export const contributorsData: ContributorsData = {
     "repo": "ant-design-x-vue",
     "url": "https://github.com/wzc520pyfm/ant-design-x-vue"
   },
-  "lastUpdated": "2025-08-11T15:21:16.228Z",
+  "lastUpdated": "2025-08-12T13:24:35.741Z",
   "contributors": [
     {
       "login": "wzc520pyfm",
@@ -78,7 +78,7 @@ export const contributorsData: ContributorsData = {
       "type": "User",
       "user_view_type": "public",
       "site_admin": false,
-      "contributions": 358
+      "contributions": 360
     },
     {
       "login": "Bao0630",
@@ -1037,6 +1037,1247 @@ export const contributorsData: ContributorsData = {
         }
       ],
       "totalContributions": 3
+    },
+    {
+      "component": "bubble-docs",
+      "path": "docs/component/bubble.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 22,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 24
+    },
+    {
+      "component": "sender-docs",
+      "path": "docs/component/sender.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 2,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 18
+    },
+    {
+      "component": "welcome-docs",
+      "path": "docs/component/welcome.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "attachments-docs",
+      "path": "docs/component/attachments.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 16
+    },
+    {
+      "component": "conversations-docs",
+      "path": "docs/component/conversations.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 10
+    },
+    {
+      "component": "prompts-docs",
+      "path": "docs/component/prompts.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 13
+    },
+    {
+      "component": "suggestion-docs",
+      "path": "docs/component/suggestion.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 6
+    },
+    {
+      "component": "thought-chain-docs",
+      "path": "docs/component/thought-chain.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 10
+    },
+    {
+      "component": "x-provider-docs",
+      "path": "docs/component/x-provider.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "x-request-docs",
+      "path": "docs/component/x-request.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "x-stream-docs",
+      "path": "docs/component/x-stream.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "use-x-agent-docs",
+      "path": "docs/component/use-x-agent.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "use-x-chat-docs",
+      "path": "docs/component/use-x-chat.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "bubble-examples",
+      "path": "docs/examples/bubble",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 11,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 12
+    },
+    {
+      "component": "sender-examples",
+      "path": "docs/examples/sender",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 12,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        }
+      ],
+      "totalContributions": 35
+    },
+    {
+      "component": "welcome-examples",
+      "path": "docs/examples/welcome",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "attachments-examples",
+      "path": "docs/examples/attachments",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "conversations-examples",
+      "path": "docs/examples/conversations",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 13
+    },
+    {
+      "component": "prompts-examples",
+      "path": "docs/examples/prompts",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 6
+    },
+    {
+      "component": "suggestion-examples",
+      "path": "docs/examples/suggestion",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ],
+      "totalContributions": 4
+    },
+    {
+      "component": "thought-chain-examples",
+      "path": "docs/examples/thought-chain",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 10
+    },
+    {
+      "component": "x-provider-examples",
+      "path": "docs/examples/x-provider",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "x-request-examples",
+      "path": "docs/examples/x-request",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "x-stream-examples",
+      "path": "docs/examples/x-stream",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "use-x-agent-examples",
+      "path": "docs/examples/use-x-agent",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 9
+    },
+    {
+      "component": "use-x-chat-examples",
+      "path": "docs/examples/use-x-chat",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 12
+    },
+    {
+      "component": "playground-examples",
+      "path": "docs/examples/playground",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "bubble-examples-setup",
+      "path": "docs/examples-setup/bubble",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "LIKUN",
+          "id": 1993555782,
+          "avatar_url": "https://github.com/LIKUN.png",
+          "html_url": "https://github.com/LIKUN",
+          "contributions": 3,
+          "type": "User",
+          "email": "45332012+StudyDayByDay@users.noreply.github.com"
+        },
+        {
+          "login": "superlollipop",
+          "id": 404479352,
+          "avatar_url": "https://github.com/superlollipop.png",
+          "html_url": "https://github.com/superlollipop",
+          "contributions": 1,
+          "type": "User",
+          "email": "1769128867@qq.com"
+        }
+      ],
+      "totalContributions": 12
+    },
+    {
+      "component": "sender-examples-setup",
+      "path": "docs/examples-setup/sender",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "专注的小眼神",
+          "id": 367769364,
+          "avatar_url": "https://github.com/专注的小眼神.png",
+          "html_url": "https://github.com/专注的小眼神",
+          "contributions": 1,
+          "type": "User",
+          "email": "36788851+Jarvis2018@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 13
+    },
+    {
+      "component": "welcome-examples-setup",
+      "path": "docs/examples-setup/welcome",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "attachments-examples-setup",
+      "path": "docs/examples-setup/attachments",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ],
+      "totalContributions": 8
+    },
+    {
+      "component": "conversations-examples-setup",
+      "path": "docs/examples-setup/conversations",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "prompts-examples-setup",
+      "path": "docs/examples-setup/prompts",
+      "contributors": [
+        {
+          "login": "K.Os",
+          "id": 1728422765,
+          "avatar_url": "https://github.com/K.Os.png",
+          "html_url": "https://github.com/K.Os",
+          "contributions": 1,
+          "type": "User",
+          "email": "100918163+chaosll@users.noreply.github.com"
+        },
+        {
+          "login": "zhangqiang",
+          "id": 1610780964,
+          "avatar_url": "https://github.com/zhangqiang.png",
+          "html_url": "https://github.com/zhangqiang",
+          "contributions": 1,
+          "type": "User",
+          "email": "44993003+JACK-ZHANG-coming@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 3
+    },
+    {
+      "component": "suggestion-examples-setup",
+      "path": "docs/examples-setup/suggestion",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "thought-chain-examples-setup",
+      "path": "docs/examples-setup/thought-chain",
+      "contributors": [
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 3,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "x-provider-examples-setup",
+      "path": "docs/examples-setup/x-provider",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "x-request-examples-setup",
+      "path": "docs/examples-setup/x-request",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 4,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 5
+    },
+    {
+      "component": "x-stream-examples-setup",
+      "path": "docs/examples-setup/x-stream",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ],
+      "totalContributions": 2
+    },
+    {
+      "component": "use-x-agent-examples-setup",
+      "path": "docs/examples-setup/use-x-agent",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        }
+      ],
+      "totalContributions": 7
+    },
+    {
+      "component": "use-x-chat-examples-setup",
+      "path": "docs/examples-setup/use-x-chat",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 4
+    },
+    {
+      "component": "playground-examples-setup",
+      "path": "docs/examples-setup/playground",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        }
+      ],
+      "totalContributions": 6
     }
   ],
   "fileContributors": [
@@ -1417,6 +2658,1165 @@ export const contributorsData: ContributorsData = {
           "contributions": 3,
           "type": "User",
           "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/bubble.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 22,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/sender.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 2,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/welcome.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/attachments.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/conversations.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/prompts.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 10,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
+        },
+        {
+          "login": "Zoey Zhao",
+          "id": 1477523806,
+          "avatar_url": "https://github.com/Zoey Zhao.png",
+          "html_url": "https://github.com/Zoey Zhao",
+          "contributions": 1,
+          "type": "User",
+          "email": "70888488+zoeyzhao19@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/suggestion.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/thought-chain.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/x-provider.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/x-request.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/x-stream.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        },
+        {
+          "login": "XiangYu Liu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/XiangYu Liu.png",
+          "html_url": "https://github.com/XiangYu Liu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/use-x-agent.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/component/use-x-chat.md",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 7,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/bubble/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 11,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/sender/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 20,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf",
+          "id": 1191901315,
+          "avatar_url": "https://github.com/linhf.png",
+          "html_url": "https://github.com/linhf",
+          "contributions": 12,
+          "type": "User",
+          "email": "linhf123"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "Wang Hao",
+          "id": 835951396,
+          "avatar_url": "https://github.com/Wang Hao.png",
+          "html_url": "https://github.com/Wang Hao",
+          "contributions": 1,
+          "type": "User",
+          "email": "710876099@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/welcome/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/attachments/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/conversations/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/prompts/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/suggestion/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 1310087455,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 1,
+          "type": "User",
+          "email": "1959099976@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/thought-chain/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 2,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/x-provider/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/x-request/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/x-stream/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 2,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/use-x-agent/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 9,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/use-x-chat/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 12,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples/playground/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/bubble/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "LIKUN",
+          "id": 1993555782,
+          "avatar_url": "https://github.com/LIKUN.png",
+          "html_url": "https://github.com/LIKUN",
+          "contributions": 3,
+          "type": "User",
+          "email": "45332012+StudyDayByDay@users.noreply.github.com"
+        },
+        {
+          "login": "superlollipop",
+          "id": 404479352,
+          "avatar_url": "https://github.com/superlollipop.png",
+          "html_url": "https://github.com/superlollipop",
+          "contributions": 1,
+          "type": "User",
+          "email": "1769128867@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/sender/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 8,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "PeikyLiu",
+          "id": 1322818178,
+          "avatar_url": "https://github.com/PeikyLiu.png",
+          "html_url": "https://github.com/PeikyLiu",
+          "contributions": 1,
+          "type": "User",
+          "email": "46105662+PeikyLiu@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        },
+        {
+          "login": "专注的小眼神",
+          "id": 367769364,
+          "avatar_url": "https://github.com/专注的小眼神.png",
+          "html_url": "https://github.com/专注的小眼神",
+          "contributions": 1,
+          "type": "User",
+          "email": "36788851+Jarvis2018@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/welcome/basic.vue",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/attachments/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 5,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "linhf123",
+          "id": 665374900,
+          "avatar_url": "https://github.com/linhf123.png",
+          "html_url": "https://github.com/linhf123",
+          "contributions": 2,
+          "type": "User",
+          "email": "32009993+linhf123@users.noreply.github.com"
+        },
+        {
+          "login": "Kieran Wang",
+          "id": 1837988216,
+          "avatar_url": "https://github.com/Kieran Wang.png",
+          "html_url": "https://github.com/Kieran Wang",
+          "contributions": 1,
+          "type": "User",
+          "email": "kieranwme@gmail.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/conversations/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 2,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/prompts/basic.vue",
+      "contributors": [
+        {
+          "login": "K.Os",
+          "id": 1728422765,
+          "avatar_url": "https://github.com/K.Os.png",
+          "html_url": "https://github.com/K.Os",
+          "contributions": 1,
+          "type": "User",
+          "email": "100918163+chaosll@users.noreply.github.com"
+        },
+        {
+          "login": "zhangqiang",
+          "id": 1610780964,
+          "avatar_url": "https://github.com/zhangqiang.png",
+          "html_url": "https://github.com/zhangqiang",
+          "contributions": 1,
+          "type": "User",
+          "email": "44993003+JACK-ZHANG-coming@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/suggestion/basic.vue",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/thought-chain/basic.vue",
+      "contributors": [
+        {
+          "login": "inCBle",
+          "id": 1187357362,
+          "avatar_url": "https://github.com/inCBle.png",
+          "html_url": "https://github.com/inCBle",
+          "contributions": 3,
+          "type": "User",
+          "email": "84701254+inCBle@users.noreply.github.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/x-provider/basic.vue",
+      "contributors": [
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/x-request/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 4,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/x-stream/basic.vue",
+      "contributors": [
+        {
+          "login": "归谜",
+          "id": 458446194,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "925122985@qq.com"
+        },
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 1,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/use-x-agent/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 6,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "归谜",
+          "id": 1768331091,
+          "avatar_url": "https://github.com/归谜.png",
+          "html_url": "https://github.com/归谜",
+          "contributions": 1,
+          "type": "User",
+          "email": "vhxubo@gmail.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/use-x-chat/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        }
+      ]
+    },
+    {
+      "file": "docs/examples-setup/playground/basic.vue",
+      "contributors": [
+        {
+          "login": "wzc520pyfm",
+          "id": 958506417,
+          "avatar_url": "https://github.com/wzc520pyfm.png",
+          "html_url": "https://github.com/wzc520pyfm",
+          "contributions": 3,
+          "type": "User",
+          "email": "1528857653@qq.com"
+        },
+        {
+          "login": "clddup",
+          "id": 286078754,
+          "avatar_url": "https://github.com/clddup.png",
+          "html_url": "https://github.com/clddup",
+          "contributions": 1,
+          "type": "User",
+          "email": "105873086+clddup@users.noreply.github.com"
+        },
+        {
+          "login": "Bao",
+          "id": 1849804005,
+          "avatar_url": "https://github.com/Bao.png",
+          "html_url": "https://github.com/Bao",
+          "contributions": 1,
+          "type": "User",
+          "email": "52953943+Bao0630@users.noreply.github.com"
+        },
+        {
+          "login": "hihanley",
+          "id": 295532086,
+          "avatar_url": "https://github.com/hihanley.png",
+          "html_url": "https://github.com/hihanley",
+          "contributions": 1,
+          "type": "User",
+          "email": "43161625+hihanley@users.noreply.github.com"
         }
       ]
     }

--- a/docs/.vitepress/vitepress/components/DocContributors.vue
+++ b/docs/.vitepress/vitepress/components/DocContributors.vue
@@ -1,0 +1,355 @@
+<template>
+  <div class="doc-contributors">
+    <div class="contributors-header">
+      <h3 class="contributors-title">
+        <svg class="title-icon" viewBox="0 0 16 16" width="18" height="18">
+          <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        贡献者
+      </h3>
+    </div>
+    
+    <div class="contributors-list">
+      <div 
+        v-for="contributor in contributorsList" 
+        :key="contributor.id"
+        class="contributor-wrapper"
+        @click="openProfile(contributor.html_url)"
+        @mouseenter="showTooltip = contributor.id"
+        @mouseleave="showTooltip = null"
+      >
+        <img 
+          :src="contributor.avatar_url" 
+          :alt="contributor.login"
+          class="contributor-avatar"
+          @error="handleImageError"
+        />
+        <div 
+          v-if="showTooltip === contributor.id"
+          class="contributor-tooltip"
+        >
+          {{ contributor.login }}
+        </div>
+      </div>
+      
+      <!-- 加载状态 -->
+      <div v-if="loading" class="loading-contributors">
+        <div class="loading-text">
+          正在加载贡献者信息...
+        </div>
+      </div>
+      
+      <!-- 如果没有找到贡献者，显示默认信息 -->
+      <div v-else-if="contributorsList.length === 0" class="no-contributors">
+        <div class="no-contributors-text">
+          暂无贡献者信息
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+interface Contributor {
+  login: string
+  id: number
+  avatar_url: string
+  html_url: string
+  contributions: number
+  type: string
+}
+
+interface FileContributor {
+  file: string
+  contributors: Contributor[]
+}
+
+interface Props {
+  componentName?: string
+  maxCount?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  componentName: '',
+  maxCount: 6
+})
+
+// 加载实际的贡献者数据
+let contributorsData: any = null
+
+// 动态导入贡献者数据
+const loadContributorsData = async () => {
+  if (contributorsData) return contributorsData
+  
+  try {
+    // 在客户端环境下动态导入
+    if (typeof window !== 'undefined') {
+      const module = await import('../../../../contributors/data.ts')
+      contributorsData = module.contributorsData
+      return contributorsData
+    } else {
+      // 服务端渲染时返回空数据
+      return {
+        contributors: [],
+        componentContributors: [],
+        fileContributors: []
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to load contributors data:', error)
+    // 返回模拟数据作为后备
+    return {
+      contributors: [
+        {
+          login: 'wzc520pyfm',
+          id: 69044080,
+          avatar_url: 'https://avatars.githubusercontent.com/u/69044080?v=4',
+          html_url: 'https://github.com/wzc520pyfm',
+          contributions: 127,
+          type: 'User'
+        }
+      ],
+      componentContributors: [],
+      fileContributors: []
+    }
+  }
+}
+
+// 响应式数据
+const allContributorsData = ref<any>(null)
+const loading = ref(true)
+const showTooltip = ref<number | null>(null)
+
+// 过滤当前组件的贡献者
+const contributorsList = computed(() => {
+  if (!allContributorsData.value || loading.value) {
+    return []
+  }
+
+  if (!props.componentName) {
+    return allContributorsData.value.contributors?.slice(0, props.maxCount) || []
+  }
+
+  // 优先使用新的 componentContributors 结构
+  if (allContributorsData.value.componentContributors) {
+    const componentData = allContributorsData.value.componentContributors.find((comp: any) => 
+      comp.component === props.componentName
+    )
+    
+    if (componentData) {
+      return componentData.contributors.slice(0, props.maxCount)
+    }
+  }
+
+  // 回退到 fileContributors 结构（向后兼容）
+  if (allContributorsData.value.fileContributors) {
+    const componentFiles = allContributorsData.value.fileContributors.filter((fc: FileContributor) => {
+      const fileName = fc.file.toLowerCase()
+      const componentName = props.componentName.toLowerCase()
+      
+      return fileName.includes(`src/${componentName}/`) || 
+             fileName.includes(`/${componentName}.vue`) ||
+             fileName.includes(`/${componentName}header.vue`) ||
+             fileName.endsWith(`${componentName}/index.vue`)
+    })
+
+    // 合并所有相关文件的贡献者
+    const contributorsMap = new Map()
+    
+    componentFiles.forEach((fileContrib: FileContributor) => {
+      fileContrib.contributors.forEach((contributor: Contributor) => {
+        const existing = contributorsMap.get(contributor.login)
+        if (existing) {
+          existing.contributions += contributor.contributions
+        } else {
+          contributorsMap.set(contributor.login, { ...contributor })
+        }
+      })
+    })
+
+    if (contributorsMap.size > 0) {
+      return Array.from(contributorsMap.values())
+        .sort((a, b) => b.contributions - a.contributions)
+        .slice(0, props.maxCount)
+    }
+  }
+
+  // 最后回退到总体贡献者
+  return allContributorsData.value.contributors?.slice(0, props.maxCount) || []
+})
+
+// 方法
+const openProfile = (url: string) => {
+  window.open(url, '_blank')
+}
+
+const handleImageError = (event: Event) => {
+  const img = event.target as HTMLImageElement
+  img.src = 'https://github.com/identicons/github.png'
+}
+
+// 加载数据
+const loadData = async () => {
+  try {
+    loading.value = true
+    const data = await loadContributorsData()
+    allContributorsData.value = data
+    console.log(`Contributors data loaded for component: ${props.componentName}`, data)
+  } catch (error) {
+    console.error('Failed to load contributors data:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(async () => {
+  console.log(`DocContributors mounted for component: ${props.componentName}`)
+  await loadData()
+})
+</script>
+
+<style scoped>
+.doc-contributors {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.contributors-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.contributors-title {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.title-icon {
+  margin-right: 8px;
+  color: var(--vp-c-brand);
+  flex-shrink: 0;
+}
+
+.contributors-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px; /* Reduced gap */
+  min-height: 60px;
+  align-items: flex-start;
+}
+
+.contributor-wrapper {
+  position: relative;
+  cursor: pointer;
+}
+
+.contributor-wrapper:hover .contributor-avatar {
+  border-color: var(--vp-c-brand);
+  transform: translateY(-1px);
+}
+
+.contributor-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid var(--vp-c-bg);
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+  display: block;
+}
+
+.contributor-tooltip {
+  position: absolute;
+  top: -36px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-1);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  z-index: 1000;
+  opacity: 1;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--vp-c-divider);
+  pointer-events: none;
+  animation: tooltip-fade-in 0.2s ease-out;
+}
+
+.contributor-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--vp-c-bg-alt);
+}
+
+@keyframes tooltip-fade-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+.loading-contributors {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+
+.loading-text {
+  opacity: 0.7;
+}
+
+.no-contributors {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+
+.no-contributors-text {
+  opacity: 0.7;
+}
+
+@media (max-width: 768px) {
+  .contributors-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .contributors-list {
+    justify-content: center;
+  }
+
+  .contributor-avatar {
+    width: 28px;
+    height: 28px;
+  }
+}
+</style> 

--- a/docs/.vitepress/vitepress/components/DocContributors.vue
+++ b/docs/.vitepress/vitepress/components/DocContributors.vue
@@ -73,7 +73,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   componentName: '',
-  maxCount: 6
+  maxCount: 50
 })
 
 // 加载实际的贡献者数据

--- a/docs/.vitepress/vitepress/index.ts
+++ b/docs/.vitepress/vitepress/index.ts
@@ -1,8 +1,10 @@
 import type { Component } from 'vue'
 import VPDemo from './components/vp-demo.vue'
 import VPSemantic from './components/vp-semantic.vue'
+import DocContributors from './components/DocContributors.vue'
 
 export const globals: [string, Component][] = [
   ['Demo', VPDemo],
   ['VpSemantic', VPSemantic],
+  ['DocContributors', DocContributors],
 ]

--- a/docs/component/attachments.md
+++ b/docs/component/attachments.md
@@ -135,3 +135,6 @@ type PresetIcons = 'default' | 'excel' | 'image' | 'markdown' | 'pdf' | 'ppt' | 
 ## 主题变量（Design Token）
 
 <!-- <ComponentTokenTable component="Prompts"></ComponentTokenTable> -->
+## 贡献者
+
+<doc-contributors component-name="attachments" :max-count="6" :show-view-all="true" />

--- a/docs/component/attachments.md
+++ b/docs/component/attachments.md
@@ -137,4 +137,4 @@ type PresetIcons = 'default' | 'excel' | 'image' | 'markdown' | 'pdf' | 'ppt' | 
 <!-- <ComponentTokenTable component="Prompts"></ComponentTokenTable> -->
 ## 贡献者
 
-<doc-contributors component-name="attachments" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="attachments" :max-count="50" :show-view-all="true" />

--- a/docs/component/bubble.md
+++ b/docs/component/bubble.md
@@ -220,4 +220,4 @@ const MyBubble = Bubble<CustomContentType>;
 
 ## 贡献者
 
-<doc-contributors component-name="bubble" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="bubble" :max-count="50" :show-view-all="true" />

--- a/docs/component/bubble.md
+++ b/docs/component/bubble.md
@@ -217,3 +217,7 @@ const MyBubble = Bubble<CustomContentType>;
 ## 主题变量（Design Token）
 
 <!-- <ComponentTokenTable component="Bubble"></ComponentTokenTable> -->
+
+## 贡献者
+
+<doc-contributors component-name="bubble" :max-count="6" :show-view-all="true" />

--- a/docs/component/conversations.md
+++ b/docs/component/conversations.md
@@ -115,3 +115,6 @@ conversations/group-sort
 | `trigger` | 自定义menu触发器 | VNode \| ((conversation: Conversation, info: \{ originNode: VNode \}) => VNode) | - | - |
 
 ## 主题变量（Design Token）
+## 贡献者
+
+<doc-contributors component-name="conversations" :max-count="6" :show-view-all="true" />

--- a/docs/component/conversations.md
+++ b/docs/component/conversations.md
@@ -117,4 +117,4 @@ conversations/group-sort
 ## 主题变量（Design Token）
 ## 贡献者
 
-<doc-contributors component-name="conversations" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="conversations" :max-count="50" :show-view-all="true" />

--- a/docs/component/prompts.md
+++ b/docs/component/prompts.md
@@ -115,4 +115,4 @@ type SemanticType = 'list' | 'item' | 'content' | 'title' | 'subList' | 'subItem
 <!-- <ComponentTokenTable component="Prompts"></ComponentTokenTable> -->
 ## 贡献者
 
-<doc-contributors component-name="prompts" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="prompts" :max-count="50" :show-view-all="true" />

--- a/docs/component/prompts.md
+++ b/docs/component/prompts.md
@@ -113,3 +113,6 @@ type SemanticType = 'list' | 'item' | 'content' | 'title' | 'subList' | 'subItem
 ## 主题变量（Design Token）
 
 <!-- <ComponentTokenTable component="Prompts"></ComponentTokenTable> -->
+## 贡献者
+
+<doc-contributors component-name="prompts" :max-count="6" :show-view-all="true" />

--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -244,4 +244,4 @@ type ActionsComponents = {
 
 ## 贡献者
 
-<doc-contributors component-name="sender" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="sender" :max-count="50" :show-view-all="true" />

--- a/docs/component/sender.md
+++ b/docs/component/sender.md
@@ -241,3 +241,7 @@ type ActionsComponents = {
 ## 主题变量（Design Token）
 
 <!-- <ComponentTokenTable component="Sender"></ComponentTokenTable> -->
+
+## 贡献者
+
+<doc-contributors component-name="sender" :max-count="6" :show-view-all="true" />

--- a/docs/component/suggestion.md
+++ b/docs/component/suggestion.md
@@ -76,3 +76,6 @@ Suggestion 接受泛型以自定义传递给 `items` renderProps 的参数类型
 ## 主题变量（Design Token）
 
 <!-- <ComponentTokenTable component="Suggestion"></ComponentTokenTable> -->
+## 贡献者
+
+<doc-contributors component-name="suggestion" :max-count="6" :show-view-all="true" />

--- a/docs/component/suggestion.md
+++ b/docs/component/suggestion.md
@@ -78,4 +78,4 @@ Suggestion 接受泛型以自定义传递给 `items` renderProps 的参数类型
 <!-- <ComponentTokenTable component="Suggestion"></ComponentTokenTable> -->
 ## 贡献者
 
-<doc-contributors component-name="suggestion" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="suggestion" :max-count="50" :show-view-all="true" />

--- a/docs/component/thought-chain.md
+++ b/docs/component/thought-chain.md
@@ -125,3 +125,6 @@ thought-chain/tooltip
 ## 主题变量（Design Token）
 
 <!-- <ComponentTokenTable component="ThoughtChain"></ComponentTokenTable> -->
+## 贡献者
+
+<doc-contributors component-name="thought-chain" :max-count="6" :show-view-all="true" />

--- a/docs/component/thought-chain.md
+++ b/docs/component/thought-chain.md
@@ -127,4 +127,4 @@ thought-chain/tooltip
 <!-- <ComponentTokenTable component="ThoughtChain"></ComponentTokenTable> -->
 ## 贡献者
 
-<doc-contributors component-name="thought-chain" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="thought-chain" :max-count="50" :show-view-all="true" />

--- a/docs/component/use-x-agent.md
+++ b/docs/component/use-x-agent.md
@@ -107,4 +107,4 @@ export type RequestFn<Message, Input, Output> = (
 | isRequesting | 是否正在请求                | () => boolean |      |
 ## 贡献者
 
-<doc-contributors component-name="use-x-agent" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="use-x-agent" :max-count="50" :show-view-all="true" />

--- a/docs/component/use-x-agent.md
+++ b/docs/component/use-x-agent.md
@@ -105,3 +105,6 @@ export type RequestFn<Message, Input, Output> = (
 | ------------ | --------------------------- | ------------- | ---- |
 | request      | 调用 `useXAgent` 配置的请求，[详情](https://antd-design-x-vue.netlify.app/component/x-request) | RequestFn     |      |
 | isRequesting | 是否正在请求                | () => boolean |      |
+## 贡献者
+
+<doc-contributors component-name="use-x-agent" :max-count="6" :show-view-all="true" />

--- a/docs/component/use-x-chat.md
+++ b/docs/component/use-x-chat.md
@@ -81,3 +81,6 @@ type useXChat<
 | 属性    | 说明           | 类型         | 默认值 | 版本 |
 | ------- | -------------- | ------------ | ------ | ---- |
 | message | 当前消息的内容 | AgentMessage | -      | -    |
+## 贡献者
+
+<doc-contributors component-name="use-x-chat" :max-count="6" :show-view-all="true" />

--- a/docs/component/use-x-chat.md
+++ b/docs/component/use-x-chat.md
@@ -83,4 +83,4 @@ type useXChat<
 | message | 当前消息的内容 | AgentMessage | -      | -    |
 ## 贡献者
 
-<doc-contributors component-name="use-x-chat" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="use-x-chat" :max-count="50" :show-view-all="true" />

--- a/docs/component/welcome.md
+++ b/docs/component/welcome.md
@@ -68,4 +68,4 @@ welcome/background
 
 ## 贡献者
 
-<doc-contributors component-name="welcome" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="welcome" :max-count="50" :show-view-all="true" />

--- a/docs/component/welcome.md
+++ b/docs/component/welcome.md
@@ -65,3 +65,7 @@ welcome/background
 <vp-semantic component="Welcome"></vp-semantic>
 
 ## 主题变量（Design Token）
+
+## 贡献者
+
+<doc-contributors component-name="welcome" :max-count="6" :show-view-all="true" />

--- a/docs/component/x-provider.md
+++ b/docs/component/x-provider.md
@@ -47,4 +47,4 @@ x-provider/use
 | thoughtChain | 思维链组件的全局配置 | 'classNames' \| 'styles' \| 'className' \| 'style' | - |  |
 ## 贡献者
 
-<doc-contributors component-name="x-provider" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="x-provider" :max-count="50" :show-view-all="true" />

--- a/docs/component/x-provider.md
+++ b/docs/component/x-provider.md
@@ -45,3 +45,6 @@ x-provider/use
 | sender | 输入框组件的全局配置 | 'classNames' \| 'styles' \| 'className' \| 'style' | - |  |
 | suggestion | 建议组件的全局配置 | 'className' \| 'style' | - |  |
 | thoughtChain | 思维链组件的全局配置 | 'classNames' \| 'styles' \| 'className' \| 'style' | - |  |
+## 贡献者
+
+<doc-contributors component-name="x-provider" :max-count="6" :show-view-all="true" />

--- a/docs/component/x-request.md
+++ b/docs/component/x-request.md
@@ -88,4 +88,4 @@ type XRequestFunction<Input = Record<PropertyKey, any>, Output = Record<string, 
 | transformStream | 可选的转换函数，用于处理流数据 | `XStreamOptions<Output>['transformStream']` | - | - |
 ## 贡献者
 
-<doc-contributors component-name="x-request" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="x-request" :max-count="50" :show-view-all="true" />

--- a/docs/component/x-request.md
+++ b/docs/component/x-request.md
@@ -86,3 +86,6 @@ type XRequestFunction<Input = Record<PropertyKey, any>, Output = Record<string, 
 | onError | 错误处理的回调。 | `(error: Error) => void` | - | - |
 | onUpdate | 消息更新的回调。 | `(chunk: Output) => void` | - | - |
 | transformStream | 可选的转换函数，用于处理流数据 | `XStreamOptions<Output>['transformStream']` | - | - |
+## 贡献者
+
+<doc-contributors component-name="x-request" :max-count="6" :show-view-all="true" />

--- a/docs/component/x-stream.md
+++ b/docs/component/x-stream.md
@@ -57,3 +57,6 @@ x-stream/custom-protocol
 | --- | --- | --- | --- | --- |
 | readableStream | ReadableStream 实例 | ReadableStream<'Uint8Array'> | - | - |
 | transformStream | 自定义的 transformStream 用于转换流的处理 | TransformStream<string, T> | sseTransformStream | - |
+## 贡献者
+
+<doc-contributors component-name="x-stream" :max-count="6" :show-view-all="true" />

--- a/docs/component/x-stream.md
+++ b/docs/component/x-stream.md
@@ -59,4 +59,4 @@ x-stream/custom-protocol
 | transformStream | 自定义的 transformStream 用于转换流的处理 | TransformStream<string, T> | sseTransformStream | - |
 ## 贡献者
 
-<doc-contributors component-name="x-stream" :max-count="6" :show-view-all="true" />
+<doc-contributors component-name="x-stream" :max-count="50" :show-view-all="true" />

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest",
     "test:cov": "vitest --coverage",
     "typecheck": "vue-tsc --noEmit",
+    "update-contributors": "node scripts/update-contributors.js",
     "play": "vite ./play"
   },
   "author": {

--- a/scripts/add-contributors-to-docs.js
+++ b/scripts/add-contributors-to-docs.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+// 组件文档目录
+const docsDir = path.join(__dirname, '../docs/component')
+
+// 需要添加贡献者部分的组件列表
+const components = [
+  { file: 'attachments.md', name: 'attachments' },
+  { file: 'conversations.md', name: 'conversations' },
+  { file: 'prompts.md', name: 'prompts' },
+  { file: 'suggestion.md', name: 'suggestion' },
+  { file: 'thought-chain.md', name: 'thought-chain' },
+  { file: 'use-x-agent.md', name: 'use-x-agent' },
+  { file: 'use-x-chat.md', name: 'use-x-chat' },
+  { file: 'x-provider.md', name: 'x-provider' },
+  { file: 'x-request.md', name: 'x-request' },
+  { file: 'x-stream.md', name: 'x-stream' }
+]
+
+// 贡献者部分的模板
+const contributorsTemplate = (componentName) => `
+## 贡献者
+
+<doc-contributors component-name="${componentName}" :max-count="6" :show-view-all="true" />`
+
+// 处理单个文件
+function processFile(filename, componentName) {
+  const filePath = path.join(docsDir, filename)
+  
+  try {
+    // 读取文件内容
+    let content = fs.readFileSync(filePath, 'utf8')
+    
+    // 检查是否已经有贡献者部分
+    if (content.includes('## 贡献者') || content.includes('<doc-contributors')) {
+      console.log(`⏭️  ${filename} already has contributors section`)
+      return false
+    }
+    
+    // 在文件末尾添加贡献者部分
+    content = content.trimEnd() + contributorsTemplate(componentName) + '\n'
+    
+    // 写回文件
+    fs.writeFileSync(filePath, content, 'utf8')
+    console.log(`✅ Added contributors to ${filename}`)
+    return true
+    
+  } catch (error) {
+    console.error(`❌ Error processing ${filename}:`, error.message)
+    return false
+  }
+}
+
+// 主函数
+function addContributorsToAllDocs() {
+  console.log('🚀 Adding contributors section to component docs...\n')
+  
+  let processedCount = 0
+  let skippedCount = 0
+  
+  components.forEach(component => {
+    const success = processFile(component.file, component.name)
+    if (success) {
+      processedCount++
+    } else {
+      skippedCount++
+    }
+  })
+  
+  console.log('\n📊 Summary:')
+  console.log(`✅ Processed: ${processedCount} files`)
+  console.log(`⏭️  Skipped: ${skippedCount} files`)
+  console.log(`📁 Total: ${components.length} files`)
+  
+  if (processedCount > 0) {
+    console.log('\n🎉 Contributors sections added successfully!')
+    console.log('💡 Remember to register the doc-contributors component in your VitePress theme.')
+  }
+}
+
+// 运行脚本
+if (require.main === module) {
+  addContributorsToAllDocs()
+}
+
+module.exports = { addContributorsToAllDocs } 

--- a/scripts/add-contributors-to-docs.js
+++ b/scripts/add-contributors-to-docs.js
@@ -24,7 +24,7 @@ const components = [
 const contributorsTemplate = (componentName) => `
 ## 贡献者
 
-<doc-contributors component-name="${componentName}" :max-count="6" :show-view-all="true" />`
+<doc-contributors component-name="${componentName}" :max-count="50" :show-view-all="true" />`
 
 // 处理单个文件
 function processFile(filename, componentName) {

--- a/scripts/collect-contributors.js
+++ b/scripts/collect-contributors.js
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+// 支持fetch polyfill
+if (typeof fetch === 'undefined') {
+  global.fetch = require('node-fetch')
+}
+
+class ComponentContributorsCollector {
+  constructor(owner, repo, outputDir = './contributors') {
+    this.owner = owner
+    this.repo = repo
+    this.outputDir = outputDir
+    this.ensureOutputDir()
+  }
+
+  ensureOutputDir() {
+    if (!fs.existsSync(this.outputDir)) {
+      fs.mkdirSync(this.outputDir, { recursive: true })
+    }
+  }
+
+  // 定义主要的组件目录
+  getComponentDirectories() {
+    const componentDirs = [
+      { name: 'bubble', path: 'src/bubble' },
+      { name: 'sender', path: 'src/sender' },
+      { name: 'welcome', path: 'src/welcome' },
+      { name: 'attachments', path: 'src/attachments' },
+      { name: 'conversations', path: 'src/conversations' },
+      { name: 'prompts', path: 'src/prompts' },
+      { name: 'suggestion', path: 'src/suggestion' },
+      { name: 'thought-chain', path: 'src/thought-chain' },
+      { name: 'x-provider', path: 'src/x-provider' },
+      { name: 'x-request', path: 'src/x-request' },
+      { name: 'x-stream', path: 'src/x-stream' },
+      { name: 'use-x-agent', path: 'src/use-x-agent' },
+      { name: 'use-x-chat', path: 'src/use-x-chat' }
+    ]
+
+    // 过滤出实际存在的目录
+    return componentDirs.filter(comp => fs.existsSync(comp.path))
+  }
+
+  // 获取指定目录的所有文件
+  getDirectoryFiles(dirPath) {
+    try {
+      const command = `find ${dirPath} -name "*.vue" -o -name "*.ts" -o -name "*.tsx" | head -20`
+      const files = execSync(command, { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+      return files
+    } catch (error) {
+      console.warn(`Could not get files for ${dirPath}:`, error.message)
+      return []
+    }
+  }
+
+  // 为单个组件目录收集贡献者
+  getComponentContributors(componentDir) {
+    console.log(`\n📁 Analyzing component: ${componentDir.name}`)
+    
+    try {
+      // 使用 git log 直接分析整个目录
+      const gitCommand = `git log --pretty=format:"%ae|%an|%cn" --follow -- "${componentDir.path}"`
+      
+      let gitLogOutput
+      try {
+        gitLogOutput = execSync(gitCommand, { encoding: 'utf8', cwd: process.cwd() })
+      } catch (e) {
+        // 尝试不使用 --follow
+        const fallbackCommand = `git log --pretty=format:"%ae|%an" -- "${componentDir.path}"`
+        try {
+          gitLogOutput = execSync(fallbackCommand, { encoding: 'utf8', cwd: process.cwd() })
+        } catch (e2) {
+          console.warn(`Could not get git log for ${componentDir.path}`)
+          return null
+        }
+      }
+
+      if (!gitLogOutput.trim()) {
+        console.warn(`No git history found for ${componentDir.path}`)
+        return null
+      }
+
+      // 解析贡献者数据
+      const authorData = gitLogOutput.split('\n').filter(Boolean)
+      const authorStats = {}
+
+      authorData.forEach(line => {
+        const parts = line.split('|')
+        const email = parts[0]
+        const authorName = parts[1]
+        const committerName = parts[2] || authorName
+
+        const name = authorName || committerName
+        if (email && name) {
+          const key = email.toLowerCase()
+          if (!authorStats[key]) {
+            authorStats[key] = { 
+              name: name.trim(), 
+              email: email.trim(),
+              commits: 0 
+            }
+          }
+          authorStats[key].commits++
+        }
+      })
+
+      // 转换为标准格式
+      const contributors = Object.entries(authorStats)
+        .map(([email, data]) => ({
+          login: data.name,
+          id: this.hashCode(email),
+          avatar_url: `https://github.com/${data.name}.png`,
+          html_url: `https://github.com/${data.name}`,
+          contributions: data.commits,
+          type: 'User',
+          email: data.email
+        }))
+        .sort((a, b) => b.contributions - a.contributions)
+        .slice(0, 50) // 每个组件最多50位贡献者
+
+      if (contributors.length > 0) {
+        console.log(`  ✅ Found ${contributors.length} contributors for ${componentDir.name}`)
+        return {
+          component: componentDir.name,
+          path: componentDir.path,
+          contributors: contributors,
+          totalContributions: contributors.reduce((sum, c) => sum + c.contributions, 0)
+        }
+      } else {
+        console.warn(`  ❌ No contributors found for ${componentDir.name}`)
+        return null
+      }
+
+    } catch (error) {
+      console.error(`Error analyzing ${componentDir.name}:`, error.message)
+      return null
+    }
+  }
+
+  // 获取GitHub总体贡献者
+  async fetchGitHubContributors() {
+    console.log('🔄 Fetching contributors from GitHub API...')
+    
+    try {
+      const url = `https://api.github.com/repos/${this.owner}/${this.repo}/contributors`
+      const response = await fetch(url)
+      
+      if (!response.ok) {
+        throw new Error(`GitHub API responded with ${response.status}`)
+      }
+      
+      const contributors = await response.json()
+      console.log(`✅ Found ${contributors.length} total contributors from GitHub`)
+      return contributors
+    } catch (error) {
+      console.warn('GitHub API failed, using mock data:', error.message)
+      return this.getMockContributors()
+    }
+  }
+
+  // Mock数据
+  getMockContributors() {
+    return [
+      {
+        login: 'wzc520pyfm',
+        id: 69044080,
+        avatar_url: 'https://avatars.githubusercontent.com/u/69044080?v=4',
+        html_url: 'https://github.com/wzc520pyfm',
+        contributions: 127,
+        type: 'User'
+      },
+      {
+        login: 'contributor-1',
+        id: 2,
+        avatar_url: 'https://github.com/github.png',
+        html_url: 'https://github.com/contributor-1',
+        contributions: 45,
+        type: 'User'
+      }
+    ]
+  }
+
+  // 简单的字符串哈希函数
+  hashCode(str) {
+    let hash = 0
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i)
+      hash = ((hash << 5) - hash) + char
+      hash = hash & hash // 转换为32位整数
+    }
+    return Math.abs(hash)
+  }
+
+  // 主收集函数
+  async collect() {
+    console.log(`🚀 Collecting contributors for ${this.owner}/${this.repo}...`)
+    console.log('📋 Using component-directory-based collection strategy\n')
+
+    try {
+      // 1. 获取组件目录
+      const componentDirs = this.getComponentDirectories()
+      console.log(`📁 Found ${componentDirs.length} component directories:`)
+      componentDirs.forEach(comp => console.log(`  - ${comp.name} (${comp.path})`))
+
+      // 2. 获取GitHub总体贡献者
+      const allContributors = await this.fetchGitHubContributors()
+
+      // 3. 按组件目录收集贡献者
+      const componentContributors = []
+      
+      for (const componentDir of componentDirs) {
+        const componentData = this.getComponentContributors(componentDir)
+        if (componentData) {
+          componentContributors.push(componentData)
+        }
+      }
+
+      console.log(`\n📊 Collection Summary:`)
+      console.log(`  - Total components analyzed: ${componentContributors.length}`)
+      console.log(`  - Total GitHub contributors: ${allContributors.length}`)
+
+      // 4. 生成最终数据结构
+      const finalData = {
+        total: allContributors.length,
+        repository: {
+          owner: this.owner,
+          repo: this.repo,
+          url: `https://github.com/${this.owner}/${this.repo}`
+        },
+        lastUpdated: new Date().toISOString(),
+        contributors: allContributors,
+        componentContributors: componentContributors, // 新的结构
+        // 保持向后兼容
+        fileContributors: this.convertToFileContributors(componentContributors)
+      }
+
+      // 5. 保存数据
+      await this.saveData(finalData)
+      
+      console.log('\n✅ Contributors collection completed successfully!')
+      return finalData
+
+    } catch (error) {
+      console.error('❌ Error during collection:', error)
+      throw error
+    }
+  }
+
+  // 转换为文件级别的贡献者（向后兼容）
+  convertToFileContributors(componentContributors) {
+    const fileContributors = []
+    
+    componentContributors.forEach(comp => {
+      // 为每个组件创建一个主文件条目
+      const mainFile = `${comp.path}/${this.getMainFileName(comp.component)}`
+      fileContributors.push({
+        file: mainFile,
+        contributors: comp.contributors
+      })
+    })
+    
+    return fileContributors
+  }
+
+  // 获取组件的主文件名
+  getMainFileName(componentName) {
+    const fileNameMap = {
+      'bubble': 'Bubble.vue',
+      'sender': 'Sender.vue',
+      'welcome': 'Welcome.vue',
+      'attachments': 'Attachments.vue',
+      'conversations': 'Conversations.vue',
+      'prompts': 'Prompts.vue',
+      'suggestion': 'Suggestion.vue',
+      'thought-chain': 'ThoughtChain.vue',
+      'x-provider': 'index.vue',
+      'x-request': 'x-request.ts',
+      'x-stream': 'x-stream.ts',
+      'use-x-agent': 'use-x-agent.ts',
+      'use-x-chat': 'use-x-chat.ts'
+    }
+    
+    return fileNameMap[componentName] || 'index.vue'
+  }
+
+  // 保存数据
+  async saveData(data) {
+    try {
+      // 保存 JSON 文件
+      const jsonPath = path.join(this.outputDir, 'contributors.json')
+      fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2))
+
+      // 保存 TypeScript 文件
+      const tsContent = this.generateTSFile(data)
+      const tsPath = path.join(this.outputDir, 'data.ts')
+      fs.writeFileSync(tsPath, tsContent)
+
+      console.log('\n💾 Contributors data saved to:')
+      console.log(`  - ${jsonPath}`)
+      console.log(`  - ${tsPath}`)
+
+    } catch (error) {
+      console.error('Error saving data:', error)
+      throw error
+    }
+  }
+
+  // 生成TypeScript文件内容
+  generateTSFile(data) {
+    return `// This file is auto-generated. Do not edit manually.
+// Last updated: ${data.lastUpdated}
+
+export interface Contributor {
+  login: string
+  id: number
+  node_id?: string
+  avatar_url: string
+  gravatar_id?: string
+  url?: string
+  html_url: string
+  followers_url?: string
+  following_url?: string
+  gists_url?: string
+  starred_url?: string
+  subscriptions_url?: string
+  organizations_url?: string
+  repos_url?: string
+  events_url?: string
+  received_events_url?: string
+  type: string
+  site_admin?: boolean
+  contributions: number
+  email?: string
+}
+
+export interface ComponentContributor {
+  component: string
+  path: string
+  contributors: Contributor[]
+  totalContributions: number
+}
+
+export interface FileContributor {
+  file: string
+  contributors: Contributor[]
+}
+
+export interface ContributorsData {
+  total: number
+  repository: {
+    owner: string
+    repo: string
+    url: string
+  }
+  lastUpdated: string
+  contributors: Contributor[]
+  componentContributors: ComponentContributor[]
+  fileContributors: FileContributor[]
+}
+
+export const contributorsData: ContributorsData = ${JSON.stringify(data, null, 2)}
+`
+  }
+}
+
+// 主函数
+async function main() {
+  const collector = new ComponentContributorsCollector('wzc520pyfm', 'ant-design-x-vue')
+  await collector.collect()
+}
+
+if (require.main === module) {
+  main().catch(console.error)
+}
+
+module.exports = { ComponentContributorsCollector } 

--- a/scripts/update-contributors.js
+++ b/scripts/update-contributors.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process')
+const path = require('path')
+
+console.log('🚀 开始更新贡献者数据...')
+
+try {
+  // 运行贡献者收集脚本
+  console.log('📊 正在收集贡献者数据...')
+  execSync('node scripts/collect-contributors.js', { 
+    stdio: 'inherit',
+    cwd: process.cwd()
+  })
+  
+  console.log('✅ 贡献者数据更新完成！')
+  console.log('📁 数据已保存到 contributors/ 目录')
+} catch (error) {
+  console.error('❌ 更新失败:', error.message)
+  process.exit(1)
+} 


### PR DESCRIPTION
效果如下
<img width="2288" height="1284" alt="image" src="https://github.com/user-attachments/assets/cead66c6-8df8-4e8b-a791-408bb1ae9c22" />


核心实现:
Git历史分析: 使用 git log 命令分析每个组件目录的提交历史
GitHub API集成: 通过GitHub API获取详细的贡献者信息（头像、用户名等）
数据聚合:
按组件目录统计贡献次数
合并相同作者的多个邮箱账号
生成组件级和文件级的贡献者统计

```javascript
// 分析Git历史
const gitCommand = `git log --pretty=format:"%ae|%an|%cn" --follow -- "${componentDir.path}"`

// 统计贡献次数
authorData.forEach(line => {
  const [email, authorName] = line.split('|')
  authorStats[email] = (authorStats[email] || 0) + 1
})
``` 



- Added a new `DocContributors` component to display contributors in documentation.
- Updated multiple component documentation files to include a contributors section.
- Introduced scripts for collecting and updating contributor data automatically.
- Added a new entry in `package.json` for updating contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Contributors widget to docs: avatar grid, tooltips, profile links, and configurable per-component or global lists.

* **Documentation**
  * Inserted “贡献者” sections across multiple component docs to showcase top contributors with a view-all option.

* **Chores**
  * Added tooling and an npm script to collect, generate, and refresh contributor datasets used by the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->