### PR TITLE
fix(suggestion): fix open prop reactive

### DIFF
--- a/src/suggestion/Suggestion.vue
+++ b/src/suggestion/Suggestion.vue
@@ -4,7 +4,7 @@ import type { RenderChildrenProps, SuggestionItem, SuggestionProps } from './int
 import { useXProviderContext } from '../x-provider';
 import useXComponentConfig from '../_util/hooks/use-x-component-config';
 import useStyle from './style';
-import { computed, type VNode, ref } from 'vue';
+import { computed, type VNode, ref, watch } from 'vue';
 import useState from '../_util/hooks/use-state';
 import { Cascader, type CascaderProps } from 'ant-design-vue';
 import useActive from './useActive';
@@ -56,6 +56,9 @@ const dropdownStyle = computed(() => {
 // =========================== Trigger ============================
 const [mergedOpen, setOpen] = useState(open);
 
+watch(() => open, (nextOpen) => {
+  setOpen(nextOpen);
+});
 
 const [info, setInfo] = useState<T | undefined>();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the Suggestion component stays in sync with the external open state. The component now updates its internal state when the open prop changes after initial render, preventing stale or inconsistent open/close behavior when controlled by parents.
  * Improves reliability for controlled usage patterns, fixing cases where toggling the open prop did not reflect in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->