### PR TITLE
fix(bubble): fix list auto scroll no work on init

### DIFF
--- a/src/bubble/BubbleList.vue
+++ b/src/bubble/BubbleList.vue
@@ -107,7 +107,7 @@ const onInternalScroll = (e: Event) => {
   );
 };
 
-watch(updateCount, () => {
+watch([updateCount, listRef, scrollReachEnd], () => {
   if (autoScroll && unref(listRef) && unref(scrollReachEnd)) {
     nextTick(() => {
       unref(listRef).scrollTo({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scroll reliability in the bubble/message list. The view now consistently sticks to the latest messages when new items arrive, when the list first loads, and when reaching the end. This reduces cases where the list failed to auto-scroll, ensuring smoother conversation flow and less manual scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->