### PR TITLE
flx(sender): modifying 'allowSpeech' changes the response loss in the property

### DIFF
--- a/src/sender/useSpeech.ts
+++ b/src/sender/useSpeech.ts
@@ -49,7 +49,7 @@ export default function useSpeech(
         onControlledRecordingChange: undefined,
         speechInControlled: false,
       }
-    }).value;
+    });
 const controlledRecording = computed(() => allowSpeechItem.value.controlledRecording);
 const onControlledRecordingChange = computed(() => allowSpeechItem.value.onControlledRecordingChange);
 const speechInControlled = computed(() => allowSpeechItem.value.speechInControlled);
@@ -89,7 +89,6 @@ const speechInControlled = computed(() => allowSpeechItem.value.speechInControll
   // ========================== Speech Events ==========================
   const recognitionRef = ref<any | null>(null);
   const [recording, setRecording] = useMergedState(false, {
-  //value type compatibility
     value: controlledRecording,
   });
 


### PR DESCRIPTION
clone bug #431 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal speech-control state and reactive handling have been reorganized to simplify recording logic and handler invocation paths.
* **User Impact**
  * No visible changes for end users; speech recording behavior and public interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->