### PR TITLE
improve(bubble): optimize typing hook

### DIFF
--- a/src/bubble/hooks/useTypedEffect.ts
+++ b/src/bubble/hooks/useTypedEffect.ts
@@ -55,13 +55,11 @@ const useTypedEffect = (
       // If there's no common prefix, start from beginning
       // If there's a common prefix, start from the point where they differ
       if (commonPrefixLength === 0) {
+        // Scenario 1: No common prefix, start from the beginning (AI completely changes the thinking process of the answer).
         setTypingIndex(1);
-      } else if (commonPrefixLength < content.value.length) {
-        // Start from the next character after the common prefix
-        setTypingIndex(commonPrefixLength + 1);
       } else {
-        // New content is shorter or same as common prefix, show all
-        setTypingIndex(content.value.length);
+        // Scenario 2: There is a common prefix, start from the point where they differ (common streaming output scenario)
+        setTypingIndex(commonPrefixLength + 1);
       }
     }
   }, { immediate: true });


### PR DESCRIPTION
When `content` is updated, if the previous content is a subset (prefix) of the new content, it will continue to output. If there are differences, it will intelligently continue output from the common prefix difference point instead of restarting. 

For example, when updating from "The weather is nice today." to "The weather is bad today.", it will continue typing from "bad".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced typing animation behavior when content changes, ensuring the animation resumes at the appropriate position even when content is significantly modified or shortened.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->