### PR TITLE
feat(use-x-chat): add updating status

### DIFF
--- a/docs/examples-setup/use-x-chat/stream.vue
+++ b/docs/examples-setup/use-x-chat/stream.vue
@@ -54,6 +54,7 @@ const { onRequest, messages } = useXChat({
       :style="{ maxHeight: 300 }"
       :items="messages.map(({ id, message, status }) => ({
         key: id,
+        loading: status === 'loading',
         role: status === 'local' ? 'local' : 'ai',
         content: message,
       }))"

--- a/docs/examples/use-x-chat/stream.vue
+++ b/docs/examples/use-x-chat/stream.vue
@@ -52,6 +52,7 @@ defineRender(() => {
         style={{ maxHeight: 300 }}
         items={messages.value.map(({ id, message, status }) => ({
           key: id,
+          loading: status === 'loading',
           role: status === 'local' ? 'local' : 'ai',
           content: message,
         }))}

--- a/src/use-x-chat/use-x-chat.ts
+++ b/src/use-x-chat/use-x-chat.ts
@@ -8,7 +8,7 @@ import type { AnyObject } from '../_util/type';
 
 export type SimpleType = string | number | boolean | object;
 
-export type MessageStatus = 'local' | 'loading' | 'success' | 'error';
+export type MessageStatus = 'local' | 'loading' | 'updating' | 'success' | 'error';
 
 type RequestPlaceholderFn<Message extends SimpleType> = (
   message: Message,
@@ -195,8 +195,8 @@ export default function useXChat<
     // Add placeholder message
     setMessages((ori) => {
       let nextMessages = [...ori, createMessage(message, 'local')];
+      let placeholderMsg = '' as AgentMessage;
       if (requestPlaceholder) {
-        let placeholderMsg: AgentMessage;
 
         if (typeof requestPlaceholder === 'function') {
           // typescript has bug that not get real return type when use `typeof function` check
@@ -206,11 +206,11 @@ export default function useXChat<
         } else {
           placeholderMsg = requestPlaceholder;
         }
-        const loadingMsg = createMessage(placeholderMsg, 'loading');
-        loadingMsgId = loadingMsg.id;
-
-        nextMessages = [...nextMessages, loadingMsg];
       }
+      const loadingMsg = createMessage(placeholderMsg, 'loading');
+      loadingMsgId = loadingMsg.id;
+
+      nextMessages = [...nextMessages, loadingMsg];
 
       return nextMessages;
     });
@@ -261,7 +261,7 @@ export default function useXChat<
       } as Input,
       {
         onUpdate: (chunk) => {
-          updateMessage('loading', chunk, []);
+          updateMessage('updating', chunk, []);
         },
         onSuccess: (chunks) => {
           updateMessage('success', undefined as Output, chunks);


### PR DESCRIPTION
之前的行为：

使用流式返回时，消息更新的回调（onUpdate）status为`loading`

新的行为：

使用流式返回时，消息更新的回调（onUpdate）设置status为`updating`而不是`loading`，以此区分开loading和updating。

这样，流式返回和非流式返回就可以使用相同的方式设置bubble loading：

```tsx
  const { onRequest, messages } = useXChat({
    agent,
  });

<Bubble.List
        roles={roles}
        style={{ maxHeight: 300 }}
        items={messages.map(({ id, message, status }) => ({
          key: id,
          // Loading
          loading: status === 'loading',
          role: status === 'local' ? 'local' : 'ai',
          content: message,
        }))}
      />
```
